### PR TITLE
프로필 이미지 관리 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,9 @@ dependencies {
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    // S3
+    implementation 'io.awspring.cloud:spring-cloud-aws-s3:3.0.2'
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/vidcentral/api/application/auth/JwtProviderService.java
+++ b/src/main/java/com/vidcentral/api/application/auth/JwtProviderService.java
@@ -106,10 +106,10 @@ public class JwtProviderService {
 			log.warn("[✅ LOGGER] JWT 토큰이 만료되었습니다.");
 		} catch (IllegalArgumentException illegalArgumentException) {
 			log.warn("[✅ LOGGER] JWT 토큰이 존재하지 않습니다.");
-			throw new NotFoundException(FAILED_TOKEN_NOT_FOUND);
+			throw new NotFoundException(FAILED_TOKEN_NOT_FOUND_ERROR);
 		} catch (Exception exception) {
 			log.warn("[✅ LOGGER] 유효하지 않은 토큰입니다.");
-			throw new NotFoundException(FAILED_INVALID_TOKEN);
+			throw new NotFoundException(FAILED_INVALID_TOKEN_ERROR);
 		}
 
 		return false;
@@ -134,13 +134,13 @@ public class JwtProviderService {
 	private void validateRefreshToken(String reGenerateRefreshToken, String savedRefreshToken) {
 		if (!reGenerateRefreshToken.equals(savedRefreshToken)) {
 			log.warn("[✅ LOGGER] 유효하지 않은 리프레시 토큰입니다.");
-			throw new NotFoundException(FAILED_TOKEN_NOT_FOUND);
+			throw new NotFoundException(FAILED_TOKEN_NOT_FOUND_ERROR);
 		}
 	}
 
 	private void validateTokenResponse(TokenSaveResponse tokenSaveResponse) {
 		if (tokenSaveResponse == null || tokenSaveResponse.refreshToken() == null) {
-			throw new NotFoundException(FAILED_UNAUTHORIZED_MEMBER);
+			throw new NotFoundException(FAILED_UNAUTHORIZED_MEMBER_ERROR);
 		}
 	}
 }

--- a/src/main/java/com/vidcentral/api/application/image/ImageService.java
+++ b/src/main/java/com/vidcentral/api/application/image/ImageService.java
@@ -1,0 +1,44 @@
+package com.vidcentral.api.application.image;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.vidcentral.api.domain.image.ImageName;
+import com.vidcentral.api.domain.image.ImageProcessor;
+import com.vidcentral.api.domain.image.ImageProperties;
+import com.vidcentral.api.domain.image.NewImage;
+import com.vidcentral.api.infrastructure.s3.S3ManagerService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ImageService {
+
+	private final S3ManagerService s3ManagerService;
+
+	@Transactional
+	public List<String> uploadImages(List<? extends MultipartFile> multipartFiles, ImageProperties imageProperties) {
+		return multipartFiles.stream()
+			.map(multipartFile -> processImageUpload(multipartFile, imageProperties))
+			.collect(Collectors.toList());
+	}
+
+	@Transactional
+	public void deleteImage(String imageURL) {
+		s3ManagerService.deleteImageFile(imageURL);
+	}
+
+	private String processImageUpload(MultipartFile multipartFile, ImageProperties imageProperties) {
+		final ImageName imageName = ImageName.createFromMultipartFile(multipartFile, imageProperties);
+		final ImageProcessor imageProcessor = new ImageProcessor(multipartFile);
+		final NewImage resizedImage = imageProcessor.resizeImageToProperties(imageProperties);
+
+		return s3ManagerService.uploadImageFile(imageName.getFileName(), resizedImage);
+	}
+}

--- a/src/main/java/com/vidcentral/api/application/member/MemberReadService.java
+++ b/src/main/java/com/vidcentral/api/application/member/MemberReadService.java
@@ -1,6 +1,5 @@
 package com.vidcentral.api.application.member;
 
-import static com.vidcentral.global.common.util.ImageURL.*;
 import static com.vidcentral.global.error.model.ErrorMessage.*;
 
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -11,7 +10,6 @@ import com.vidcentral.api.domain.member.repository.MemberRepository;
 import com.vidcentral.global.error.exception.BadRequestException;
 import com.vidcentral.global.error.exception.ConflictException;
 import com.vidcentral.global.error.exception.NotFoundException;
-import com.vidcentral.global.error.model.ErrorMessage;
 
 import lombok.RequiredArgsConstructor;
 
@@ -24,43 +22,35 @@ public class MemberReadService {
 
 	public Member readMember(Long memberId) {
 		return memberRepository.findById(memberId)
-			.orElseThrow(() -> new NotFoundException(ErrorMessage.FAILED_MEMBER_NOT_FOUND));
+			.orElseThrow(() -> new NotFoundException(FAILED_MEMBER_NOT_FOUND_ERROR));
 	}
 
 	public Member findMember(String email) {
 		return memberRepository.findMemberByEmail(email)
-			.orElseThrow(() -> new NotFoundException(ErrorMessage.FAILED_MEMBER_NOT_FOUND));
+			.orElseThrow(() -> new NotFoundException(FAILED_MEMBER_NOT_FOUND_ERROR));
 	}
 
 	public void validateEmailDuplication(String email) {
 		if (memberRepository.existsMemberByEmail(email)) {
-			throw new ConflictException(FAILED_EMAIL_DUPLICATION);
+			throw new ConflictException(FAILED_EMAIL_DUPLICATION_ERROR);
 		}
 	}
 
 	public void validateNicknameDuplication(String nickname) {
 		if (memberRepository.existsMemberByNickname(nickname)) {
-			throw new ConflictException(FAILED_NICKNAME_DUPLICATION);
+			throw new ConflictException(FAILED_NICKNAME_DUPLICATION_ERROR);
 		}
 	}
 
 	public void validatePasswordMatch(String password, String checkPassword) {
 		if (!password.equals(checkPassword)) {
-			throw new ConflictException(FAILED_PASSWORD_MISMATCH);
+			throw new ConflictException(FAILED_PASSWORD_MISMATCH_ERROR);
 		}
 	}
 
 	public void validateLoginPasswordMatch(String rawPassword, String encodedPassword) {
 		if (!passwordEncoder.matches(rawPassword, encodedPassword)) {
-			throw new BadRequestException(FAILED_INVALID_PASSWORD);
-		}
-	}
-
-	public void validateProfileImageURLExtension(String profileImageURL) {
-		if (profileImageURL == null || (!profileImageURL.toLowerCase().endsWith(JPG) && !profileImageURL.toLowerCase()
-			.endsWith(JPEG) && !profileImageURL.toLowerCase().endsWith(PNG))) {
-
-			throw new ConflictException(FAILED_INVALID_IMAGE_EXTENSION);
+			throw new BadRequestException(FAILED_INVALID_PASSWORD_ERROR);
 		}
 	}
 }

--- a/src/main/java/com/vidcentral/api/application/member/MemberService.java
+++ b/src/main/java/com/vidcentral/api/application/member/MemberService.java
@@ -1,9 +1,15 @@
 package com.vidcentral.api.application.member;
 
+import static com.vidcentral.api.domain.image.ImageProperties.*;
+
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.vidcentral.api.application.auth.AuthorizationService;
+import com.vidcentral.api.application.image.ImageService;
 import com.vidcentral.api.domain.auth.entity.AuthMember;
 import com.vidcentral.api.domain.member.entity.Member;
 import com.vidcentral.api.dto.request.auth.LoginRequest;
@@ -23,6 +29,7 @@ public class MemberService {
 	private final MemberWriteService memberWriteService;
 	private final MemberReadService memberReadService;
 	private final AuthorizationService authorizationService;
+	private final ImageService imageService;
 
 	@Transactional
 	public void signUpMember(SignUpRequest signUpRequest) {
@@ -47,11 +54,11 @@ public class MemberService {
 	}
 
 	@Transactional
-	public void updateMemberInfo(AuthMember authMember, UpdateRequest updateRequest) {
+	public void updateMemberInfo(AuthMember authMember, UpdateRequest updateRequest, MultipartFile profileImageURL) {
 		final Member loginMember = memberReadService.findMember(authMember.email());
 		memberReadService.validateNicknameDuplication(updateRequest.nickname());
-		memberReadService.validateProfileImageURLExtension(updateRequest.profileImageURL());
 
-		memberWriteService.updateMemberInfo(loginMember, updateRequest);
+		String newProfileImageURL = imageService.uploadImages(List.of(profileImageURL), PROFILE_IMAGE).get(0);
+		memberWriteService.changeMemberInfo(loginMember, updateRequest, newProfileImageURL);
 	}
 }

--- a/src/main/java/com/vidcentral/api/application/member/MemberWriteService.java
+++ b/src/main/java/com/vidcentral/api/application/member/MemberWriteService.java
@@ -21,9 +21,9 @@ public class MemberWriteService {
 		memberRepository.save(MemberMapper.toMember(signUpRequest, passwordEncoder.encode(signUpRequest.password())));
 	}
 
-	public void updateMemberInfo(Member member, UpdateRequest updateRequest) {
+	public void changeMemberInfo(Member member, UpdateRequest updateRequest, String newProfileImageURL) {
 		member.updateIntroduce(updateRequest.introduce());
-		member.updateProfileImageURL(updateRequest.profileImageURL());
 		member.updateNickname(updateRequest.nickname());
+		member.updateProfileImageURL(newProfileImageURL);
 	}
 }

--- a/src/main/java/com/vidcentral/api/domain/image/ImageName.java
+++ b/src/main/java/com/vidcentral/api/domain/image/ImageName.java
@@ -1,0 +1,27 @@
+package com.vidcentral.api.domain.image;
+
+import static com.vidcentral.global.common.util.GlobalConstant.*;
+
+import java.util.UUID;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class ImageName {
+
+	private static final String PROFILE_IMAGE = "members/profile" + DELIMITER;
+
+	private final String fileName;
+
+	public static ImageName createFromMultipartFile(MultipartFile multipartFile, ImageProperties imageProperties) {
+		return switch (imageProperties) {
+			case PROFILE_IMAGE ->
+				new ImageName(PROFILE_IMAGE + multipartFile.getName() + "_" + UUID.randomUUID() + IMAGE_EXTENSION);
+		};
+	}
+}

--- a/src/main/java/com/vidcentral/api/domain/image/ImageProcessor.java
+++ b/src/main/java/com/vidcentral/api/domain/image/ImageProcessor.java
@@ -1,0 +1,83 @@
+package com.vidcentral.api.domain.image;
+
+import static com.vidcentral.global.error.model.ErrorMessage.*;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import javax.imageio.ImageIO;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import com.vidcentral.global.error.exception.BadRequestException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public record ImageProcessor(
+	MultipartFile originalImageFile
+) {
+
+	private static final String IMAGE_FORMAT_PREFIX = "image/";
+	private static final int MAX_IMAGE_SIZE = 10 * 1024 * 1024;
+
+	public ImageProcessor(MultipartFile originalImageFile) {
+		this.originalImageFile = validateImage(originalImageFile);
+	}
+
+	public NewImage resizeImageToProperties(ImageProperties imageProperties) {
+		BufferedImage bufferedImage = getBufferedImage();
+		int width = imageProperties.getWidth();
+		int height = getResizedHeight(width, bufferedImage);
+
+		BufferedImage scaledImage = resizeImage(bufferedImage, width, height);
+		byte[] bytes = convertBufferedImageToByteArray(scaledImage);
+
+		return NewImage.of(originalImageFile.getOriginalFilename(), originalImageFile.getContentType(), bytes);
+	}
+
+	private MultipartFile validateImage(MultipartFile imageFile) {
+		if (imageFile.isEmpty() || imageFile.getSize() > MAX_IMAGE_SIZE || !imageFile.getContentType()
+			.startsWith(IMAGE_FORMAT_PREFIX)) {
+			throw new BadRequestException(FAILED_S3_RESIZE_ERROR);
+		}
+
+		return imageFile;
+	}
+
+	private int getResizedHeight(int width, BufferedImage bufferedImage) {
+		double ratio = (double)width / bufferedImage.getWidth();
+		return (int)(bufferedImage.getHeight() * ratio);
+	}
+
+	private BufferedImage resizeImage(BufferedImage bufferedImage, int width, int height) {
+		BufferedImage scaledImage = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+
+		Graphics graphics = scaledImage.getGraphics();
+		graphics.drawImage(bufferedImage.getScaledInstance(width, height, Image.SCALE_SMOOTH), 0, 0, null);
+		graphics.dispose();
+
+		return scaledImage;
+	}
+
+	private BufferedImage getBufferedImage() {
+		try {
+			return ImageIO.read(originalImageFile.getInputStream());
+		} catch (IOException e) {
+			log.error("[✅ LOGGER] 이미지 리사이징 에러", e);
+			throw new BadRequestException(FAILED_S3_RESIZE_ERROR);
+		}
+	}
+
+	private byte[] convertBufferedImageToByteArray(BufferedImage image) {
+		try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+			ImageIO.write(image, "png", outputStream);
+			return outputStream.toByteArray();
+		} catch (IOException e) {
+			log.error("[✅ LOGGER] 이미지 리사이징 에러", e);
+			throw new BadRequestException(FAILED_S3_RESIZE_ERROR);
+		}
+	}
+}

--- a/src/main/java/com/vidcentral/api/domain/image/ImageProperties.java
+++ b/src/main/java/com/vidcentral/api/domain/image/ImageProperties.java
@@ -1,0 +1,18 @@
+package com.vidcentral.api.domain.image;
+
+import lombok.Getter;
+
+@Getter
+public enum ImageProperties {
+
+	PROFILE_IMAGE(150, "image/png");
+
+	private final int width;
+	private final String contentType;
+
+	ImageProperties(int width, String contentType) {
+		this.width = width;
+		this.contentType = contentType;
+	}
+
+}

--- a/src/main/java/com/vidcentral/api/domain/image/NewImage.java
+++ b/src/main/java/com/vidcentral/api/domain/image/NewImage.java
@@ -1,0 +1,67 @@
+package com.vidcentral.api.domain.image;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class NewImage implements MultipartFile {
+
+	private final String name;
+	private final String contentType;
+	private final long size;
+	private final byte[] bytes;
+
+	public static NewImage of(String name, String contentType, byte[] bytes) {
+		return new NewImage(name, contentType, bytes.length, bytes);
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public String getOriginalFilename() {
+		return name;
+	}
+
+	@Override
+	public String getContentType() {
+		return contentType;
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return false;
+	}
+
+	@Override
+	public long getSize() {
+		return size;
+	}
+
+	@Override
+	public byte[] getBytes() {
+		return bytes;
+	}
+
+	@Override
+	public InputStream getInputStream() {
+		return new ByteArrayInputStream(bytes);
+	}
+
+	@Override
+	public void transferTo(File dest) throws IOException, IllegalStateException {
+		try (FileOutputStream fileOutputStream = new FileOutputStream(dest)) {
+			fileOutputStream.write(this.getBytes());
+		}
+	}
+}

--- a/src/main/java/com/vidcentral/api/domain/member/entity/Member.java
+++ b/src/main/java/com/vidcentral/api/domain/member/entity/Member.java
@@ -49,7 +49,7 @@ public class Member extends BaseTimeEntity {
 		this.password = password;
 		this.nickname = nickname;
 		this.introduce = INTRODUCE_ME;
-		this.profileImage = DEFAULT_IMAGE_DOMAIN + MEMBER_PROFILE_URL;
+		this.profileImage = IMAGE_DOMAIN + MEMBER_PROFILE_URL;
 	}
 
 	public void updateNickname(String nickname) {

--- a/src/main/java/com/vidcentral/api/dto/request/member/UpdateRequest.java
+++ b/src/main/java/com/vidcentral/api/dto/request/member/UpdateRequest.java
@@ -11,8 +11,6 @@ public record UpdateRequest(
 	String nickname,
 
 	@Size(max = 50, message = "소개글은 최대 50자까지 입력이 가능합니다.")
-	String introduce,
-
-	String profileImageURL
+	String introduce
 ) {
 }

--- a/src/main/java/com/vidcentral/api/infrastructure/s3/S3ManagerService.java
+++ b/src/main/java/com/vidcentral/api/infrastructure/s3/S3ManagerService.java
@@ -1,0 +1,53 @@
+package com.vidcentral.api.infrastructure.s3;
+
+import java.io.IOException;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.RequiredArgsConstructor;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Service
+@RequiredArgsConstructor
+public class S3ManagerService {
+
+	private final S3Client s3Client;
+
+	@Value("${cloud.aws.s3.bucket}")
+	private String bucketName;
+
+	@Value("${cloud.aws.cloudfront.domain}")
+	private String cloudFrontURL;
+
+	public String uploadImageFile(String key, MultipartFile multipartFile) {
+		try {
+			PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+				.bucket(bucketName)
+				.key(key)
+				.contentType(multipartFile.getContentType())
+				.build();
+
+			s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(multipartFile.getInputStream(), multipartFile.getSize()));
+
+			return cloudFrontURL + key;
+		} catch (IOException e) {
+			throw new RuntimeException("파일 업로드 실패", e);
+		}
+	}
+
+	public void deleteImageFile(String objectURL) {
+		String key = objectURL.replace(cloudFrontURL, "");
+
+		DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+			.bucket(bucketName)
+			.key(key)
+			.build();
+
+		s3Client.deleteObject(deleteObjectRequest);
+	}
+}

--- a/src/main/java/com/vidcentral/api/presentation/member/MemberController.java
+++ b/src/main/java/com/vidcentral/api/presentation/member/MemberController.java
@@ -8,8 +8,10 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.vidcentral.api.application.member.MemberService;
 import com.vidcentral.api.domain.auth.entity.AuthMember;
@@ -103,9 +105,10 @@ public class MemberController {
 	})
 	public ResponseEntity<String> updateMemberInfo(
 		@AuthenticationMember AuthMember authMember,
-		@Valid @RequestBody(required = false) UpdateRequest updateRequest) {
+		@Valid @RequestPart(required = false) UpdateRequest updateRequest,
+		@RequestPart(name = "profileImageURL") MultipartFile newProfileImageURL) {
 
-		memberService.updateMemberInfo(authMember, updateRequest);
+		memberService.updateMemberInfo(authMember, updateRequest, newProfileImageURL);
 		return ResponseEntity.ok().body("성공적으로 회원 정보가 업데이트되었습니다.");
 	}
 }

--- a/src/main/java/com/vidcentral/global/common/util/GlobalConstant.java
+++ b/src/main/java/com/vidcentral/global/common/util/GlobalConstant.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 public class GlobalConstant {
 
 	public static final String BLANK = "";
+	public static final String DELIMITER = "/";
 
 	public static final String INTRODUCE_ME = "본인 소개에 대한 내용을 작성해주세요.";
 

--- a/src/main/java/com/vidcentral/global/common/util/GlobalConstant.java
+++ b/src/main/java/com/vidcentral/global/common/util/GlobalConstant.java
@@ -11,6 +11,5 @@ public class GlobalConstant {
 
 	public static final String INTRODUCE_ME = "본인 소개에 대한 내용을 작성해주세요.";
 
-	public static final String SIGNUP_URI = "/api/signup";
-	public static final String LOGIN_URI = "/api/login";
+	public static final String IMAGE_EXTENSION = ".png";
 }

--- a/src/main/java/com/vidcentral/global/common/util/ImageURL.java
+++ b/src/main/java/com/vidcentral/global/common/util/ImageURL.java
@@ -6,11 +6,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ImageURL {
 
-	public static final String JPG = "jpg";
-	public static final String JPEG = "jpeg";
-	public static final String PNG = "png";
+	public static final String IMAGE_DOMAIN = "https://image.vidcentral.com/";
 
-	public static final String DEFAULT_IMAGE_DOMAIN = "https://image.vidcentral.com/";
-	public static final String MEMBER_PROFILE_URL = "default/member-profile.png";
-	public static final String IMAGE_EXTENSION = ".png";
+	public static final String MEMBER_PROFILE_URL = "vidcentral/default/members-profile.png";
 }

--- a/src/main/java/com/vidcentral/global/common/util/ImageURL.java
+++ b/src/main/java/com/vidcentral/global/common/util/ImageURL.java
@@ -6,10 +6,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ImageURL {
 
-	public static final String JPG = ".jpg";
-	public static final String JPEG = ".jpeg";
-	public static final String PNG = ".png";
+	public static final String JPG = "jpg";
+	public static final String JPEG = "jpeg";
+	public static final String PNG = "png";
 
 	public static final String DEFAULT_IMAGE_DOMAIN = "https://image.vidcentral.com/";
 	public static final String MEMBER_PROFILE_URL = "default/member-profile.png";
+	public static final String IMAGE_EXTENSION = ".png";
 }

--- a/src/main/java/com/vidcentral/global/config/S3Config.java
+++ b/src/main/java/com/vidcentral/global/config/S3Config.java
@@ -1,0 +1,33 @@
+package com.vidcentral.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+	@Value("${cloud.aws.credentials.access-key}")
+	private String accessKey;
+
+	@Value("${cloud.aws.credentials.secret-key}")
+	private String secretKey;
+
+	@Value("${cloud.aws.region.static}")
+	private String staticRegion;
+
+	@Bean
+	public S3Client s3Client() {
+		AwsBasicCredentials awsBasicCredentials = AwsBasicCredentials.create(accessKey, secretKey);
+
+		return S3Client.builder()
+			.region(Region.of(staticRegion))
+			.credentialsProvider(StaticCredentialsProvider.create(awsBasicCredentials))
+			.build();
+	}
+}

--- a/src/main/java/com/vidcentral/global/error/model/ErrorMessage.java
+++ b/src/main/java/com/vidcentral/global/error/model/ErrorMessage.java
@@ -8,16 +8,17 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum ErrorMessage {
 
-	FAILED_INVALID_REQUEST("[❎ ERROR] 잘못된 요청입니다. 입력한 데이터가 유효하지 않습니다."),
-	FAILED_INVALID_PASSWORD("[❎ ERROR] 입력하신 비밀번호는 틀린 비밀번호입니다."),
-	FAILED_INVALID_TOKEN("[❎ ERROR] 유효하지 않은 토큰입니다."),
-	FAILED_INVALID_IMAGE_EXTENSION("[❎ ERROR] 유효하지 않은 이미지 확장자입니다."),
-	FAILED_UNAUTHORIZED_MEMBER("[❎ ERROR] 해당 사용자는 인증되지 않은 사용자입니다."),
-	FAILED_EMAIL_DUPLICATION("[❎ ERROR] 입력하신 이메일은 이미 존재하는 이메일입니다."),
-	FAILED_NICKNAME_DUPLICATION("[❎ ERROR] 입력하신 닉네임은 이미 존재하는 닉네임입니다."),
-	FAILED_PASSWORD_MISMATCH("[❎ ERROR] 입력하신 비밀번호와 일치하지 않습니다."),
-	FAILED_MEMBER_NOT_FOUND("[❎ ERROR] 요청하신 사용자는 존재하지 않는 사용자입니다."),
-	FAILED_TOKEN_NOT_FOUND("[❎ ERROR] JWT 토큰이 존재하지 않습니다."),
+	FAILED_INVALID_REQUEST_ERROR("[❎ ERROR] 잘못된 요청입니다. 입력한 데이터가 유효하지 않습니다."),
+	FAILED_INVALID_PASSWORD_ERROR("[❎ ERROR] 입력하신 비밀번호는 틀린 비밀번호입니다."),
+	FAILED_INVALID_TOKEN_ERROR("[❎ ERROR] 유효하지 않은 토큰입니다."),
+	FAILED_INVALID_IMAGE_EXTENSION_ERROR("[❎ ERROR] 유효하지 않은 이미지 확장자입니다."),
+	FAILED_S3_RESIZE_ERROR("[❎ ERROR] S3 이미지 리사이즈에 실패했습니다."),
+	FAILED_UNAUTHORIZED_MEMBER_ERROR("[❎ ERROR] 해당 사용자는 인증되지 않은 사용자입니다."),
+	FAILED_EMAIL_DUPLICATION_ERROR("[❎ ERROR] 입력하신 이메일은 이미 존재하는 이메일입니다."),
+	FAILED_NICKNAME_DUPLICATION_ERROR("[❎ ERROR] 입력하신 닉네임은 이미 존재하는 닉네임입니다."),
+	FAILED_PASSWORD_MISMATCH_ERROR("[❎ ERROR] 입력하신 비밀번호와 일치하지 않습니다."),
+	FAILED_MEMBER_NOT_FOUND_ERROR("[❎ ERROR] 요청하신 사용자는 존재하지 않는 사용자입니다."),
+	FAILED_TOKEN_NOT_FOUND_ERROR("[❎ ERROR] JWT 토큰이 존재하지 않습니다."),
 
 	FAILED_UNKNOWN_ERROR("[❎ ERROR] 서버에서 알 수 없는 에러가 발생했습니다.");
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,3 +30,14 @@ spring:
   redis:
     host: localhost
     port: 6379
+
+cloud:
+  aws:
+    s3:
+      bucket: your-bucket-name
+    cloudfront:
+      domain: your-cloudfront-domain
+    credentials:
+      access-key: your-access-key
+      secret-key: your-secret-key
+    region: your-region


### PR DESCRIPTION
## AWS S3 및 CloudFront 설정 추가
- application.yml에 S3 버킷 이름, CloudFront 도메인, 액세스 키 및 비밀 키를 임시로 설정 추가

## 프로필 이미지 관리 서비스 로직 구현
- S3ManagerService 클래스 추가
- 프로필 이미지 업로드 및 삭제 기능 구현

## 사용자 프로필 이미지 업데이트 로직 리팩토링
- 기존 프로필 이미지 업데이트 로직을 S3ManagerService를 사용하도록 리팩토링