### PR TITLE
비디오 조회 & 시청 기록 생성 및 조회 API 구현

### DIFF
--- a/src/main/java/com/vidcentral/api/application/auth/AnonymousMemberService.java
+++ b/src/main/java/com/vidcentral/api/application/auth/AnonymousMemberService.java
@@ -1,0 +1,30 @@
+package com.vidcentral.api.application.auth;
+
+import static com.vidcentral.global.common.util.TokenConstant.*;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
+import com.vidcentral.global.common.util.CookieUtils;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Service
+public class AnonymousMemberService {
+
+	public String getOrCreateAnonymousId(HttpServletResponse httpServletResponse, String existingAnonymousId) {
+		if (existingAnonymousId.isEmpty()) return createAnonymousId(httpServletResponse);
+		return existingAnonymousId;
+	}
+
+	private String createAnonymousId(HttpServletResponse httpServletResponse) {
+		String anonymousId = UUID.randomUUID().toString();
+
+		Cookie anonymousCookie = CookieUtils.generateAnonymousIdCookie(ANONYMOUS_ID_COOKIE, anonymousId);
+		httpServletResponse.addCookie(anonymousCookie);
+
+		return anonymousId;
+	}
+}

--- a/src/main/java/com/vidcentral/api/application/video/VideoMapper.java
+++ b/src/main/java/com/vidcentral/api/application/video/VideoMapper.java
@@ -3,6 +3,7 @@ package com.vidcentral.api.application.video;
 import com.vidcentral.api.domain.member.entity.Member;
 import com.vidcentral.api.domain.video.entity.Video;
 import com.vidcentral.api.dto.request.video.UploadVideoRequest;
+import com.vidcentral.api.dto.response.video.VideoInfoResponse;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -16,6 +17,15 @@ public class VideoMapper {
 			.title(uploadVideoRequest.title())
 			.description(uploadVideoRequest.description())
 			.videoURL(videoURL)
+			.build();
+	}
+
+	public static VideoInfoResponse toVideoInfoResponse(Video video) {
+		return VideoInfoResponse.builder()
+			.nickname(video.getMember().getNickname())
+			.title(video.getTitle())
+			.description(video.getDescription())
+			.videoURL(video.getVideoURL())
 			.build();
 	}
 }

--- a/src/main/java/com/vidcentral/api/application/video/VideoMapper.java
+++ b/src/main/java/com/vidcentral/api/application/video/VideoMapper.java
@@ -17,6 +17,7 @@ public class VideoMapper {
 			.title(uploadVideoRequest.title())
 			.description(uploadVideoRequest.description())
 			.videoURL(videoURL)
+			.videoTags(uploadVideoRequest.videoTags())
 			.build();
 	}
 

--- a/src/main/java/com/vidcentral/api/application/video/VideoMapper.java
+++ b/src/main/java/com/vidcentral/api/application/video/VideoMapper.java
@@ -3,7 +3,8 @@ package com.vidcentral.api.application.video;
 import com.vidcentral.api.domain.member.entity.Member;
 import com.vidcentral.api.domain.video.entity.Video;
 import com.vidcentral.api.dto.request.video.UploadVideoRequest;
-import com.vidcentral.api.dto.response.video.VideoInfoResponse;
+import com.vidcentral.api.dto.response.video.VideoDetailResponse;
+import com.vidcentral.api.dto.response.video.VideoListResponse;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -21,12 +22,22 @@ public class VideoMapper {
 			.build();
 	}
 
-	public static VideoInfoResponse toVideoInfoResponse(Video video) {
-		return VideoInfoResponse.builder()
+	public static VideoListResponse toVideoInfoResponse(Video video) {
+		return VideoListResponse.builder()
+			.nickname(video.getMember().getNickname())
+			.title(video.getTitle())
+			.videoURL(video.getVideoURL())
+			.views(video.getViews())
+			.build();
+	}
+
+	public static VideoDetailResponse toVideoDetailsResponse(Video video) {
+		return VideoDetailResponse.builder()
 			.nickname(video.getMember().getNickname())
 			.title(video.getTitle())
 			.description(video.getDescription())
 			.videoURL(video.getVideoURL())
+			.views(video.getViews())
 			.build();
 	}
 }

--- a/src/main/java/com/vidcentral/api/application/video/VideoReadService.java
+++ b/src/main/java/com/vidcentral/api/application/video/VideoReadService.java
@@ -14,6 +14,7 @@ import com.vidcentral.api.domain.auth.entity.AuthMember;
 import com.vidcentral.api.domain.video.entity.Video;
 import com.vidcentral.api.domain.video.entity.VideoTag;
 import com.vidcentral.api.domain.video.repository.VideoRepository;
+import com.vidcentral.api.dto.response.viewHistory.ViewHistoryListResponse;
 import com.vidcentral.global.error.exception.BadRequestException;
 import com.vidcentral.global.error.exception.NotFoundException;
 
@@ -46,6 +47,12 @@ public class VideoReadService {
 				loginMember -> viewHistoryService.saveViewHistory(loginMember, video),
 				() -> sessionViewHistoryService.addSessionViewHistory(anonymousId, video)
 			);
+	}
+
+	public List<ViewHistoryListResponse> searchAllViewHistory(AuthMember authMember, String anonymousId) {
+		return Optional.ofNullable(authMember)
+			.map(viewHistoryService::searchAllViewHistoryForLoggedInMember)
+			.orElseGet(() -> viewHistoryService.searchAllViewHistoryForAnonymousMember(anonymousId));
 	}
 
 	public void validateMemberHasAccess(String videoOwnerEmail, String authMemberEmail) {

--- a/src/main/java/com/vidcentral/api/application/video/VideoReadService.java
+++ b/src/main/java/com/vidcentral/api/application/video/VideoReadService.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 
 import com.vidcentral.api.domain.video.entity.Video;
+import com.vidcentral.api.domain.video.entity.VideoTag;
 import com.vidcentral.api.domain.video.repository.VideoRepository;
 import com.vidcentral.global.error.exception.BadRequestException;
 import com.vidcentral.global.error.exception.NotFoundException;
@@ -16,6 +17,8 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class VideoReadService {
+
+	private static final int MAX_TAG_COUNT = 3;
 
 	private final VideoRepository videoRepository;
 
@@ -31,6 +34,12 @@ public class VideoReadService {
 	public void validateMemberHasAccess(String videoOwnerEmail, String authMemberEmail) {
 		if (!videoOwnerEmail.equals(authMemberEmail)) {
 			throw new BadRequestException(FAILED_INVALID_VIDEO_ACCESS_ERROR);
+		}
+	}
+
+	public void validateTagCount(List<VideoTag> videoTags) {
+		if (videoTags == null || videoTags.size() > MAX_TAG_COUNT) {
+			throw new BadRequestException(FAILED_MAX_TAG_COUNT_ERROR);
 		}
 	}
 }

--- a/src/main/java/com/vidcentral/api/application/video/VideoReadService.java
+++ b/src/main/java/com/vidcentral/api/application/video/VideoReadService.java
@@ -2,6 +2,8 @@ package com.vidcentral.api.application.video;
 
 import static com.vidcentral.global.error.model.ErrorMessage.*;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
 import com.vidcentral.api.domain.video.entity.Video;
@@ -20,6 +22,10 @@ public class VideoReadService {
 	public Video findVideo(Long videoId) {
 		return videoRepository.findById(videoId)
 			.orElseThrow(() -> new NotFoundException(FAILED_VIDEO_NOT_FOUND_ERROR));
+	}
+
+	public List<Video> findAllVideos() {
+		return videoRepository.findAll();
 	}
 
 	public void validateMemberHasAccess(String videoOwnerEmail, String authMemberEmail) {

--- a/src/main/java/com/vidcentral/api/application/video/VideoService.java
+++ b/src/main/java/com/vidcentral/api/application/video/VideoService.java
@@ -2,6 +2,8 @@ package com.vidcentral.api.application.video;
 
 import static com.vidcentral.api.domain.video.entity.VideoProperties.*;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -14,6 +16,7 @@ import com.vidcentral.api.domain.video.entity.Video;
 import com.vidcentral.api.domain.video.repository.VideoRepository;
 import com.vidcentral.api.dto.request.video.UpdateVideoRequest;
 import com.vidcentral.api.dto.request.video.UploadVideoRequest;
+import com.vidcentral.api.dto.response.video.VideoInfoResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -37,9 +40,16 @@ public class VideoService {
 		return videoRepository.save(video);
 	}
 
+	public List<VideoInfoResponse> searchAllVideos() {
+		List<Video> videoList = videoReadService.findAllVideos();
+
+		return videoList.stream()
+			.map(VideoMapper::toVideoInfoResponse)
+			.toList();
+	}
+
 	@Transactional
-	public void updateVideo(AuthMember authMember, Long videoId, UpdateVideoRequest updateVideoRequest,
-		MultipartFile videoURL) {
+	public void updateVideo(AuthMember authMember, Long videoId, UpdateVideoRequest updateVideoRequest, MultipartFile videoURL) {
 		final Member loginMember = memberReadService.findMember(authMember.email());
 		final Video video = videoReadService.findVideo(videoId);
 		videoReadService.validateMemberHasAccess(video.getMember().getEmail(), loginMember.getEmail());

--- a/src/main/java/com/vidcentral/api/application/video/VideoService.java
+++ b/src/main/java/com/vidcentral/api/application/video/VideoService.java
@@ -18,6 +18,7 @@ import com.vidcentral.api.dto.request.video.UpdateVideoRequest;
 import com.vidcentral.api.dto.request.video.UploadVideoRequest;
 import com.vidcentral.api.dto.response.video.VideoDetailResponse;
 import com.vidcentral.api.dto.response.video.VideoListResponse;
+import com.vidcentral.api.dto.response.viewHistory.ViewHistoryListResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -56,6 +57,10 @@ public class VideoService {
 		videoReadService.saveViewHistory(authMember, video, anonymousId);
 		videoWriteService.incrementVideoViews(video);
 		return VideoMapper.toVideoDetailsResponse(video);
+	}
+
+	public List<ViewHistoryListResponse> searchAllViewHistory(AuthMember authMember, String anonymousId) {
+		return videoReadService.searchAllViewHistory(authMember, anonymousId);
 	}
 
 	@Transactional

--- a/src/main/java/com/vidcentral/api/application/video/VideoService.java
+++ b/src/main/java/com/vidcentral/api/application/video/VideoService.java
@@ -59,7 +59,9 @@ public class VideoService {
 	public void updateVideo(AuthMember authMember, Long videoId, UpdateVideoRequest updateVideoRequest, MultipartFile videoURL) {
 		final Member loginMember = memberReadService.findMember(authMember.email());
 		final Video video = videoReadService.findVideo(videoId);
+
 		videoReadService.validateMemberHasAccess(video.getMember().getEmail(), loginMember.getEmail());
+		videoReadService.validateTagCount(updateVideoRequest.videoTags());
 
 		final String newVideoURL = mediaService.uploadVideo(videoURL, DEFAULT_VIDEO);
 		videoWriteService.updateVideo(video, updateVideoRequest, newVideoURL);

--- a/src/main/java/com/vidcentral/api/application/video/VideoService.java
+++ b/src/main/java/com/vidcentral/api/application/video/VideoService.java
@@ -16,7 +16,8 @@ import com.vidcentral.api.domain.video.entity.Video;
 import com.vidcentral.api.domain.video.repository.VideoRepository;
 import com.vidcentral.api.dto.request.video.UpdateVideoRequest;
 import com.vidcentral.api.dto.request.video.UploadVideoRequest;
-import com.vidcentral.api.dto.response.video.VideoInfoResponse;
+import com.vidcentral.api.dto.response.video.VideoDetailResponse;
+import com.vidcentral.api.dto.response.video.VideoListResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -42,7 +43,7 @@ public class VideoService {
 		return videoRepository.save(video);
 	}
 
-	public List<VideoInfoResponse> searchAllVideos() {
+	public List<VideoListResponse> searchAllVideos() {
 		List<Video> videoList = videoReadService.findAllVideos();
 
 		return videoList.stream()
@@ -50,9 +51,10 @@ public class VideoService {
 			.toList();
 	}
 
-	public VideoInfoResponse searchVideo(Long videoId) {
+	public VideoDetailResponse searchVideo(Long videoId) {
 		final Video video = videoReadService.findVideo(videoId);
-		return VideoMapper.toVideoInfoResponse(video);
+		video.incrementViews();
+		return VideoMapper.toVideoDetailsResponse(video);
 	}
 
 	@Transactional

--- a/src/main/java/com/vidcentral/api/application/video/VideoService.java
+++ b/src/main/java/com/vidcentral/api/application/video/VideoService.java
@@ -35,6 +35,8 @@ public class VideoService {
 	public Video uploadVideo(AuthMember authMember, UploadVideoRequest uploadVideoRequest, MultipartFile newVideoURL) {
 		final String videoURL = mediaService.uploadVideo(newVideoURL, DEFAULT_VIDEO);
 		final Member loginMember = memberReadService.findMember(authMember.email());
+
+		videoReadService.validateTagCount(uploadVideoRequest.videoTags());
 		final Video video = VideoMapper.toVideo(loginMember, uploadVideoRequest, videoURL);
 
 		return videoRepository.save(video);

--- a/src/main/java/com/vidcentral/api/application/video/VideoService.java
+++ b/src/main/java/com/vidcentral/api/application/video/VideoService.java
@@ -48,6 +48,11 @@ public class VideoService {
 			.toList();
 	}
 
+	public VideoInfoResponse searchVideo(Long videoId) {
+		final Video video = videoReadService.findVideo(videoId);
+		return VideoMapper.toVideoInfoResponse(video);
+	}
+
 	@Transactional
 	public void updateVideo(AuthMember authMember, Long videoId, UpdateVideoRequest updateVideoRequest, MultipartFile videoURL) {
 		final Member loginMember = memberReadService.findMember(authMember.email());

--- a/src/main/java/com/vidcentral/api/application/video/VideoService.java
+++ b/src/main/java/com/vidcentral/api/application/video/VideoService.java
@@ -51,9 +51,10 @@ public class VideoService {
 			.toList();
 	}
 
-	public VideoDetailResponse searchVideo(Long videoId) {
+	public VideoDetailResponse searchVideo(AuthMember authMember, Long videoId, String anonymousId) {
 		final Video video = videoReadService.findVideo(videoId);
-		video.incrementViews();
+		videoReadService.saveViewHistory(authMember, video, anonymousId);
+		videoWriteService.incrementVideoViews(video);
 		return VideoMapper.toVideoDetailsResponse(video);
 	}
 

--- a/src/main/java/com/vidcentral/api/application/video/VideoWriteService.java
+++ b/src/main/java/com/vidcentral/api/application/video/VideoWriteService.java
@@ -15,5 +15,6 @@ public class VideoWriteService {
 		video.updateTitle(updateVideoRequest.title());
 		video.updateDescription(updateVideoRequest.description());
 		video.updateVideoURL(newVideoURL);
+		video.updateVideoTags(updateVideoRequest.videoTags());
 	}
 }

--- a/src/main/java/com/vidcentral/api/application/video/VideoWriteService.java
+++ b/src/main/java/com/vidcentral/api/application/video/VideoWriteService.java
@@ -17,4 +17,8 @@ public class VideoWriteService {
 		video.updateVideoURL(newVideoURL);
 		video.updateVideoTags(updateVideoRequest.videoTags());
 	}
+
+	public void incrementVideoViews(Video video) {
+		video.incrementViews();
+	}
 }

--- a/src/main/java/com/vidcentral/api/application/viewHistory/SessionViewHistoryService.java
+++ b/src/main/java/com/vidcentral/api/application/viewHistory/SessionViewHistoryService.java
@@ -1,0 +1,24 @@
+package com.vidcentral.api.application.viewHistory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Service;
+
+import com.vidcentral.api.domain.video.entity.Video;
+
+@Service
+public class SessionViewHistoryService {
+
+	private final Map<String, List<Video>> anonymousViewHistoryMap = new ConcurrentHashMap<>();
+
+	public void addSessionViewHistory(String anonymousId, Video video) {
+		anonymousViewHistoryMap.computeIfAbsent(anonymousId, viewHistory -> new ArrayList<>()).add(video);
+	}
+
+	public List<Video> getSessionViewHistory(String anonymousId) {
+		return anonymousViewHistoryMap.getOrDefault(anonymousId, new ArrayList<>());
+	}
+}

--- a/src/main/java/com/vidcentral/api/application/viewHistory/SessionViewHistoryService.java
+++ b/src/main/java/com/vidcentral/api/application/viewHistory/SessionViewHistoryService.java
@@ -8,17 +8,19 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.stereotype.Service;
 
 import com.vidcentral.api.domain.video.entity.Video;
+import com.vidcentral.api.domain.viewHistory.entity.ViewHistory;
 
 @Service
 public class SessionViewHistoryService {
 
-	private final Map<String, List<Video>> anonymousViewHistoryMap = new ConcurrentHashMap<>();
+	private final Map<String, List<ViewHistory>> anonymousViewHistoryMap = new ConcurrentHashMap<>();
 
 	public void addSessionViewHistory(String anonymousId, Video video) {
-		anonymousViewHistoryMap.computeIfAbsent(anonymousId, viewHistory -> new ArrayList<>()).add(video);
+		final ViewHistory viewHistory = ViewHistoryMapper.toViewHistory(null, video);
+		anonymousViewHistoryMap.computeIfAbsent(anonymousId, existingAnonymousId -> new ArrayList<>()).add(viewHistory);
 	}
 
-	public List<Video> getSessionViewHistory(String anonymousId) {
+	public List<ViewHistory> searchSessionViewHistory(String anonymousId) {
 		return anonymousViewHistoryMap.getOrDefault(anonymousId, new ArrayList<>());
 	}
 }

--- a/src/main/java/com/vidcentral/api/application/viewHistory/ViewHistoryMapper.java
+++ b/src/main/java/com/vidcentral/api/application/viewHistory/ViewHistoryMapper.java
@@ -1,0 +1,30 @@
+package com.vidcentral.api.application.viewHistory;
+
+import com.vidcentral.api.domain.member.entity.Member;
+import com.vidcentral.api.domain.video.entity.Video;
+import com.vidcentral.api.domain.viewHistory.entity.ViewHistory;
+import com.vidcentral.api.dto.response.viewHistory.ViewHistoryListResponse;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ViewHistoryMapper {
+
+	public static ViewHistory toViewHistory(Member member, Video video) {
+		return ViewHistory.builder()
+			.member(member)
+			.video(video)
+			.build();
+	}
+
+	public static ViewHistoryListResponse toViewHistoryListResponse(ViewHistory viewHistory) {
+		return ViewHistoryListResponse.builder()
+			.title(viewHistory.getVideo().getTitle())
+			.description(viewHistory.getVideo().getDescription())
+			.videoURL(viewHistory.getVideo().getVideoURL())
+			.views(viewHistory.getVideo().getViews())
+			.watchedAt(viewHistory.getWatchedAt())
+			.build();
+	}
+}

--- a/src/main/java/com/vidcentral/api/application/viewHistory/ViewHistoryService.java
+++ b/src/main/java/com/vidcentral/api/application/viewHistory/ViewHistoryService.java
@@ -4,6 +4,8 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
+import com.vidcentral.api.application.member.MemberReadService;
+import com.vidcentral.api.domain.auth.entity.AuthMember;
 import com.vidcentral.api.domain.member.entity.Member;
 import com.vidcentral.api.domain.video.entity.Video;
 import com.vidcentral.api.domain.viewHistory.entity.ViewHistory;
@@ -16,6 +18,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ViewHistoryService {
 
+	private final MemberReadService memberReadService;
+	private final SessionViewHistoryService sessionViewHistoryService;
 	private final ViewHistoryRepository viewHistoryRepository;
 
 	public void saveViewHistory(Member member, Video video) {
@@ -23,10 +27,17 @@ public class ViewHistoryService {
 		viewHistoryRepository.save(viewHistory);
 	}
 
-	public List<ViewHistoryListResponse> searchAllViewHistories() {
-		List<ViewHistory> viewHistoryList = viewHistoryRepository.findAll();
+	public List<ViewHistoryListResponse> searchAllViewHistoryForLoggedInMember(AuthMember authMember) {
+		final Member loginMember = memberReadService.findMember(authMember.email());
+		final List<ViewHistory> viewHistoryList = viewHistoryRepository.findViewHistoriesByMember(loginMember);
 
 		return viewHistoryList.stream()
+			.map(ViewHistoryMapper::toViewHistoryListResponse)
+			.toList();
+	}
+
+	public List<ViewHistoryListResponse> searchAllViewHistoryForAnonymousMember(String anonymousId) {
+		return sessionViewHistoryService.searchSessionViewHistory(anonymousId).stream()
 			.map(ViewHistoryMapper::toViewHistoryListResponse)
 			.toList();
 	}

--- a/src/main/java/com/vidcentral/api/application/viewHistory/ViewHistoryService.java
+++ b/src/main/java/com/vidcentral/api/application/viewHistory/ViewHistoryService.java
@@ -1,0 +1,33 @@
+package com.vidcentral.api.application.viewHistory;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.vidcentral.api.domain.member.entity.Member;
+import com.vidcentral.api.domain.video.entity.Video;
+import com.vidcentral.api.domain.viewHistory.entity.ViewHistory;
+import com.vidcentral.api.domain.viewHistory.repository.ViewHistoryRepository;
+import com.vidcentral.api.dto.response.viewHistory.ViewHistoryListResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ViewHistoryService {
+
+	private final ViewHistoryRepository viewHistoryRepository;
+
+	public void saveViewHistory(Member member, Video video) {
+		final ViewHistory viewHistory = ViewHistoryMapper.toViewHistory(member, video);
+		viewHistoryRepository.save(viewHistory);
+	}
+
+	public List<ViewHistoryListResponse> searchAllViewHistories() {
+		List<ViewHistory> viewHistoryList = viewHistoryRepository.findAll();
+
+		return viewHistoryList.stream()
+			.map(ViewHistoryMapper::toViewHistoryListResponse)
+			.toList();
+	}
+}

--- a/src/main/java/com/vidcentral/api/domain/video/entity/Video.java
+++ b/src/main/java/com/vidcentral/api/domain/video/entity/Video.java
@@ -83,4 +83,8 @@ public class Video extends BaseTimeEntity {
 	public void updateVideoTags(List<VideoTag> videoTags) {
 		this.videoTags = requireNonNullElse(videoTags, this.videoTags);
 	}
+
+	public void incrementViews() {
+		this.views++;
+	}
 }

--- a/src/main/java/com/vidcentral/api/domain/video/entity/Video.java
+++ b/src/main/java/com/vidcentral/api/domain/video/entity/Video.java
@@ -79,4 +79,8 @@ public class Video extends BaseTimeEntity {
 	public void updateVideoURL(String newVideoURL) {
 		this.videoURL = requireNonNullElse(newVideoURL, this.videoURL);
 	}
+
+	public void updateVideoTags(List<VideoTag> videoTags) {
+		this.videoTags = requireNonNullElse(videoTags, this.videoTags);
+	}
 }

--- a/src/main/java/com/vidcentral/api/domain/video/entity/Video.java
+++ b/src/main/java/com/vidcentral/api/domain/video/entity/Video.java
@@ -2,11 +2,18 @@ package com.vidcentral.api.domain.video.entity;
 
 import static java.util.Objects.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.vidcentral.api.domain.member.entity.Member;
 import com.vidcentral.global.common.entity.BaseTimeEntity;
 
+import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -43,12 +50,22 @@ public class Video extends BaseTimeEntity {
 	@Column(name = "video_url", nullable = false)
 	private String videoURL;
 
+	@Column(name = "views", nullable = false)
+	private Long views = 0L;
+
+	@ElementCollection(targetClass = VideoTag.class)
+	@CollectionTable(name = "video_tags", joinColumns = @JoinColumn(name = "video_id"))
+	@Column(name = "video_tags")
+	@Enumerated(EnumType.STRING)
+	private List<VideoTag> videoTags = new ArrayList<>();
+
 	@Builder
-	private Video(Member member, String title, String description, String videoURL) {
+	private Video(Member member, String title, String description, String videoURL, List<VideoTag> videoTags) {
 		this.member = member;
 		this.title = title;
 		this.description = description;
 		this.videoURL = videoURL;
+		this.videoTags = videoTags;
 	}
 
 	public void updateTitle(String title) {

--- a/src/main/java/com/vidcentral/api/domain/video/entity/VideoTag.java
+++ b/src/main/java/com/vidcentral/api/domain/video/entity/VideoTag.java
@@ -1,0 +1,10 @@
+package com.vidcentral.api.domain.video.entity;
+
+public enum VideoTag {
+
+	EDUCATION,
+	ENTERTAINMENT,
+	TECHNOLOGY,
+	MUSIC,
+	SPORTS
+}

--- a/src/main/java/com/vidcentral/api/domain/viewHistory/entity/ViewHistory.java
+++ b/src/main/java/com/vidcentral/api/domain/viewHistory/entity/ViewHistory.java
@@ -1,0 +1,49 @@
+package com.vidcentral.api.domain.viewHistory.entity;
+
+import java.time.LocalDateTime;
+
+import com.vidcentral.api.domain.member.entity.Member;
+import com.vidcentral.api.domain.video.entity.Video;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "VIEW_HISTORY")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ViewHistory {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long viewHistoryId;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id", nullable = false)
+	private Member member;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "video_id", nullable = false)
+	private Video video;
+
+	@Column(name = "watched_at")
+	private LocalDateTime watchedAt;
+
+	@Builder
+	private ViewHistory(Member member, Video video) {
+		this.member = member;
+		this.video = video;
+		this.watchedAt = LocalDateTime.now();
+	}
+}

--- a/src/main/java/com/vidcentral/api/domain/viewHistory/repository/ViewHistoryRepository.java
+++ b/src/main/java/com/vidcentral/api/domain/viewHistory/repository/ViewHistoryRepository.java
@@ -1,0 +1,15 @@
+package com.vidcentral.api.domain.viewHistory.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.vidcentral.api.domain.member.entity.Member;
+import com.vidcentral.api.domain.viewHistory.entity.ViewHistory;
+
+@Repository
+public interface ViewHistoryRepository extends JpaRepository<ViewHistory, Long> {
+
+	List<ViewHistory> findViewHistoriesByMember(Member member);
+}

--- a/src/main/java/com/vidcentral/api/dto/request/video/UpdateVideoRequest.java
+++ b/src/main/java/com/vidcentral/api/dto/request/video/UpdateVideoRequest.java
@@ -1,5 +1,9 @@
 package com.vidcentral.api.dto.request.video;
 
+import java.util.List;
+
+import com.vidcentral.api.domain.video.entity.VideoTag;
+
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 
@@ -8,6 +12,9 @@ public record UpdateVideoRequest(
 	@NotBlank(message = "비디오 제목은 필수 입력 항목입니다.")
 	String title,
 
-	String description
+	@NotBlank(message = "비디오 설명은 필수 입력 항목입니다.")
+	String description,
+
+	List<VideoTag> videoTags
 ) {
 }

--- a/src/main/java/com/vidcentral/api/dto/request/video/UploadVideoRequest.java
+++ b/src/main/java/com/vidcentral/api/dto/request/video/UploadVideoRequest.java
@@ -1,5 +1,9 @@
 package com.vidcentral.api.dto.request.video;
 
+import java.util.List;
+
+import com.vidcentral.api.domain.video.entity.VideoTag;
+
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 
@@ -8,6 +12,10 @@ public record UploadVideoRequest(
 	@NotBlank(message = "비디오 제목은 필수 입력 항목입니다.")
 	String title,
 
-	String description
+	@NotBlank(message = "비디오 설명은 필수 입력 항목입니다.")
+	String description,
+
+	@NotBlank(message = "비디오 태그는 필수 입력 항목입니다.")
+	List<VideoTag> videoTags
 ) {
 }

--- a/src/main/java/com/vidcentral/api/dto/response/video/VideoDetailResponse.java
+++ b/src/main/java/com/vidcentral/api/dto/response/video/VideoDetailResponse.java
@@ -1,0 +1,13 @@
+package com.vidcentral.api.dto.response.video;
+
+import lombok.Builder;
+
+@Builder
+public record VideoDetailResponse(
+	String nickname,
+	String title,
+	String description,
+	String videoURL,
+	Long views
+) {
+}

--- a/src/main/java/com/vidcentral/api/dto/response/video/VideoInfoResponse.java
+++ b/src/main/java/com/vidcentral/api/dto/response/video/VideoInfoResponse.java
@@ -1,0 +1,12 @@
+package com.vidcentral.api.dto.response.video;
+
+import lombok.Builder;
+
+@Builder
+public record VideoInfoResponse(
+	String nickname,
+	String title,
+	String description,
+	String videoURL
+) {
+}

--- a/src/main/java/com/vidcentral/api/dto/response/video/VideoListResponse.java
+++ b/src/main/java/com/vidcentral/api/dto/response/video/VideoListResponse.java
@@ -3,10 +3,10 @@ package com.vidcentral.api.dto.response.video;
 import lombok.Builder;
 
 @Builder
-public record VideoInfoResponse(
+public record VideoListResponse(
 	String nickname,
 	String title,
-	String description,
-	String videoURL
+	String videoURL,
+	Long views
 ) {
 }

--- a/src/main/java/com/vidcentral/api/dto/response/viewHistory/ViewHistoryListResponse.java
+++ b/src/main/java/com/vidcentral/api/dto/response/viewHistory/ViewHistoryListResponse.java
@@ -1,0 +1,15 @@
+package com.vidcentral.api.dto.response.viewHistory;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+
+@Builder
+public record ViewHistoryListResponse(
+	String title,
+	String description,
+	String videoURL,
+	Long views,
+	LocalDateTime watchedAt
+) {
+}

--- a/src/main/java/com/vidcentral/api/presentation/video/VideoController.java
+++ b/src/main/java/com/vidcentral/api/presentation/video/VideoController.java
@@ -25,6 +25,7 @@ import com.vidcentral.api.dto.request.video.UpdateVideoRequest;
 import com.vidcentral.api.dto.request.video.UploadVideoRequest;
 import com.vidcentral.api.dto.response.video.VideoDetailResponse;
 import com.vidcentral.api.dto.response.video.VideoListResponse;
+import com.vidcentral.api.dto.response.viewHistory.ViewHistoryListResponse;
 import com.vidcentral.global.auth.annotation.AuthenticationMember;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -71,13 +72,32 @@ public class VideoController {
 		description = "모든 비디오 제목, 설명, 파일을 조회합니다."
 	)
 	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "성공 - 모든 비디오 조회, 모든 비디오 정보를 조회했습니다.."),
+		@ApiResponse(responseCode = "200", description = "성공 - 모든 비디오 조회, 모든 비디오 정보를 조회했습니다."),
 		@ApiResponse(responseCode = "404", description = "실패 - 해당 회원을 찾을 수 없습니다."),
 		@ApiResponse(responseCode = "409", description = "실패 - 유효하지 않은 비디오 파일입니다."),
 		@ApiResponse(responseCode = "500", description = "실패 - 서버 오류, 요청 처리 중 문제가 발생했습니다.")
 	})
 	public ResponseEntity<List<VideoListResponse>> searchAllVideos() {
 		return ResponseEntity.ok().body(videoService.searchAllVideos());
+	}
+
+	@GetMapping("/view-history")
+	@ResponseStatus(HttpStatus.OK)
+	@Operation(
+		summary = "모든 비디오 시청 기록 조회 API",
+		description = "모든 비디오 제목, 설명, 파일, 조회수, 시청 시간을 조회합니다."
+	)
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "성공 - 모든 비디오 시청 기록 조회, 모든 비디오 시청 기록을 조회했습니다."),
+		@ApiResponse(responseCode = "404", description = "실패 - 해당 회원을 찾을 수 없습니다."),
+		@ApiResponse(responseCode = "409", description = "실패 - 유효하지 않은 비디오 파일입니다."),
+		@ApiResponse(responseCode = "500", description = "실패 - 서버 오류, 요청 처리 중 문제가 발생했습니다.")
+	})
+	public ResponseEntity<List<ViewHistoryListResponse>> searchAllViewHistory(
+		@AuthenticationMember AuthMember authMember,
+		@CookieValue(value = "anonymousId", defaultValue = "") String anonymousId) {
+
+		return ResponseEntity.ok().body(videoService.searchAllViewHistory(authMember, anonymousId));
 	}
 
 	@GetMapping("/{videoId}")

--- a/src/main/java/com/vidcentral/api/presentation/video/VideoController.java
+++ b/src/main/java/com/vidcentral/api/presentation/video/VideoController.java
@@ -75,6 +75,22 @@ public class VideoController {
 		return ResponseEntity.ok().body(videoService.searchAllVideos());
 	}
 
+	@GetMapping("/{videoId}")
+	@ResponseStatus(HttpStatus.OK)
+	@Operation(
+		summary = "비디오 조회 API",
+		description = "비디오 제목, 설명, 파일을 조회합니다."
+	)
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "성공 - 비디오 조회, 비디오 정보를 조회했습니다.."),
+		@ApiResponse(responseCode = "404", description = "실패 - 해당 회원을 찾을 수 없습니다."),
+		@ApiResponse(responseCode = "409", description = "실패 - 유효하지 않은 비디오 파일입니다."),
+		@ApiResponse(responseCode = "500", description = "실패 - 서버 오류, 요청 처리 중 문제가 발생했습니다.")
+	})
+	public ResponseEntity<VideoInfoResponse> searchVideo(@PathVariable Long videoId) {
+		return ResponseEntity.ok().body(videoService.searchVideo(videoId));
+	}
+
 	@PutMapping("/update/{videoId}")
 	@ResponseStatus(HttpStatus.OK)
 	@Operation(

--- a/src/main/java/com/vidcentral/api/presentation/video/VideoController.java
+++ b/src/main/java/com/vidcentral/api/presentation/video/VideoController.java
@@ -21,7 +21,8 @@ import com.vidcentral.api.domain.auth.entity.AuthMember;
 import com.vidcentral.api.domain.video.entity.Video;
 import com.vidcentral.api.dto.request.video.UpdateVideoRequest;
 import com.vidcentral.api.dto.request.video.UploadVideoRequest;
-import com.vidcentral.api.dto.response.video.VideoInfoResponse;
+import com.vidcentral.api.dto.response.video.VideoDetailResponse;
+import com.vidcentral.api.dto.response.video.VideoListResponse;
 import com.vidcentral.global.auth.annotation.AuthenticationMember;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -71,7 +72,7 @@ public class VideoController {
 		@ApiResponse(responseCode = "409", description = "실패 - 유효하지 않은 비디오 파일입니다."),
 		@ApiResponse(responseCode = "500", description = "실패 - 서버 오류, 요청 처리 중 문제가 발생했습니다.")
 	})
-	public ResponseEntity<List<VideoInfoResponse>> searchAllVideos() {
+	public ResponseEntity<List<VideoListResponse>> searchAllVideos() {
 		return ResponseEntity.ok().body(videoService.searchAllVideos());
 	}
 
@@ -87,7 +88,7 @@ public class VideoController {
 		@ApiResponse(responseCode = "409", description = "실패 - 유효하지 않은 비디오 파일입니다."),
 		@ApiResponse(responseCode = "500", description = "실패 - 서버 오류, 요청 처리 중 문제가 발생했습니다.")
 	})
-	public ResponseEntity<VideoInfoResponse> searchVideo(@PathVariable Long videoId) {
+	public ResponseEntity<VideoDetailResponse> searchVideo(@PathVariable Long videoId) {
 		return ResponseEntity.ok().body(videoService.searchVideo(videoId));
 	}
 

--- a/src/main/java/com/vidcentral/api/presentation/video/VideoController.java
+++ b/src/main/java/com/vidcentral/api/presentation/video/VideoController.java
@@ -1,10 +1,12 @@
 package com.vidcentral.api.presentation.video;
 
 import java.net.URI;
+import java.util.List;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -19,6 +21,7 @@ import com.vidcentral.api.domain.auth.entity.AuthMember;
 import com.vidcentral.api.domain.video.entity.Video;
 import com.vidcentral.api.dto.request.video.UpdateVideoRequest;
 import com.vidcentral.api.dto.request.video.UploadVideoRequest;
+import com.vidcentral.api.dto.response.video.VideoInfoResponse;
 import com.vidcentral.global.auth.annotation.AuthenticationMember;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -28,7 +31,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/video")
+@RequestMapping("/api/videos")
 @RequiredArgsConstructor
 public class VideoController {
 
@@ -54,6 +57,22 @@ public class VideoController {
 
 		Video uploadVideo = videoService.uploadVideo(authMember, uploadVideoRequest, newVideoURL);
 		return ResponseEntity.created(URI.create(uploadVideo.getVideoURL())).body(uploadVideo);
+	}
+
+	@GetMapping
+	@ResponseStatus(HttpStatus.OK)
+	@Operation(
+		summary = "모든 비디오 조회 API",
+		description = "모든 비디오 제목, 설명, 파일을 조회합니다."
+	)
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "성공 - 모든 비디오 조회, 모든 비디오 정보를 조회했습니다.."),
+		@ApiResponse(responseCode = "404", description = "실패 - 해당 회원을 찾을 수 없습니다."),
+		@ApiResponse(responseCode = "409", description = "실패 - 유효하지 않은 비디오 파일입니다."),
+		@ApiResponse(responseCode = "500", description = "실패 - 서버 오류, 요청 처리 중 문제가 발생했습니다.")
+	})
+	public ResponseEntity<List<VideoInfoResponse>> searchAllVideos() {
+		return ResponseEntity.ok().body(videoService.searchAllVideos());
 	}
 
 	@PutMapping("/update/{videoId}")

--- a/src/main/java/com/vidcentral/global/auth/filter/AuthenticationFilter.java
+++ b/src/main/java/com/vidcentral/global/auth/filter/AuthenticationFilter.java
@@ -51,7 +51,7 @@ public class AuthenticationFilter extends OncePerRequestFilter {
 				return;
 			}
 
-			throw new NotFoundException(FAILED_TOKEN_NOT_FOUND);
+			throw new NotFoundException(FAILED_TOKEN_NOT_FOUND_ERROR);
 		} catch (Exception exception) {
 			log.warn("[✅ LOGGER] JWT 에러 상세 설명: {}", exception.getMessage());
 			handlerExceptionResolver.resolveException(httpServletRequest, httpServletResponse, null, exception);

--- a/src/main/java/com/vidcentral/global/common/util/CookieUtils.java
+++ b/src/main/java/com/vidcentral/global/common/util/CookieUtils.java
@@ -1,5 +1,6 @@
 package com.vidcentral.global.common.util;
 
+import static com.vidcentral.global.common.util.GlobalConstant.*;
 import static com.vidcentral.global.common.util.TokenConstant.*;
 
 import jakarta.servlet.http.Cookie;
@@ -13,9 +14,18 @@ public class CookieUtils {
 		Cookie refreshTokenCookie = new Cookie(refreshTokenName, token);
 		refreshTokenCookie.setMaxAge(COOKIE_MAX_AGE);
 		refreshTokenCookie.setHttpOnly(true);
-		refreshTokenCookie.setPath("/");
+		refreshTokenCookie.setPath(DELIMITER);
 
 		return refreshTokenCookie;
+	}
+
+	public static Cookie generateAnonymousIdCookie(String anonymousIdName, String id) {
+		Cookie anonymousCookie = new Cookie(anonymousIdName, id);
+		anonymousCookie.setMaxAge(COOKIE_MAX_AGE);
+		anonymousCookie.setHttpOnly(true);
+		anonymousCookie.setPath(DELIMITER);
+
+		return anonymousCookie;
 	}
 
 	public static String extractRefreshTokenFromCookies(HttpServletRequest httpServletRequest) {
@@ -33,7 +43,7 @@ public class CookieUtils {
 		Cookie refreshTokenCookie = new Cookie(refreshTokenName, null);
 		refreshTokenCookie.setMaxAge(0);
 		refreshTokenCookie.setHttpOnly(true);
-		refreshTokenCookie.setPath("/");
+		refreshTokenCookie.setPath(DELIMITER);
 
 		return refreshTokenCookie;
 	}

--- a/src/main/java/com/vidcentral/global/common/util/TokenConstant.java
+++ b/src/main/java/com/vidcentral/global/common/util/TokenConstant.java
@@ -13,6 +13,7 @@ public class TokenConstant {
 
 	public static final String ACCESS_TOKEN_HEADER = "Authorization";
 	public static final String REFRESH_TOKEN_COOKIE = "Authorization_RefreshToken";
+	public static final String ANONYMOUS_ID_COOKIE = "Anonymous_Id";
 
 	public static final int EXPIRE_DAYS = 14;
 }

--- a/src/main/java/com/vidcentral/global/config/SecurityConfig.java
+++ b/src/main/java/com/vidcentral/global/config/SecurityConfig.java
@@ -34,7 +34,8 @@ public class SecurityConfig {
 		"/api/login"
 	};
 	private static final String[] MEMBER_INFO_ENDPOINTS = {
-		"/api/members/**"
+		"/api/members/**",
+		"/api/videos/**"
 	};
 
 	@Bean

--- a/src/main/java/com/vidcentral/global/error/model/ErrorMessage.java
+++ b/src/main/java/com/vidcentral/global/error/model/ErrorMessage.java
@@ -14,6 +14,7 @@ public enum ErrorMessage {
 	FAILED_INVALID_IMAGE_EXTENSION_ERROR("[❎ ERROR] 유효하지 않은 이미지 확장자입니다."),
 	FAILED_INVALID_VIDEO_ERROR("[❎ ERROR] 유효하지 않은 비디오 파일입니다."),
 	FAILED_INVALID_VIDEO_ACCESS_ERROR("[❎ ERROR] 유효하지 않은 비디오 접근입니다."),
+	FAILED_MAX_TAG_COUNT_ERROR("[❎ ERROR] 태그는 최대 3개까지 설정할 수 있습니다."),
 	FAILED_S3_RESIZE_ERROR("[❎ ERROR] S3 이미지 리사이즈에 실패했습니다."),
 	FAILED_UNAUTHORIZED_MEMBER_ERROR("[❎ ERROR] 해당 사용자는 인증되지 않은 사용자입니다."),
 	FAILED_EMAIL_DUPLICATION_ERROR("[❎ ERROR] 입력하신 이메일은 이미 존재하는 이메일입니다."),


### PR DESCRIPTION
## 비디오 조회 API 구현
- 모든 비디오와 특정 비디오를 조회하는 기능을 구현

## 시청 기록 생성 및 조회 API 구현
- 사용자가 특정 비디오를 조회할 때, 해당 비디오에 대한 시청 기록을 생성하는 로직을 구현

## 로그인 여부에 따른 시청 기록 조회
- 로그인한 사용자는 기존의 시청 기록을 그대로 조회하고, 로그인하지 않은 사용자는 익명 ID를 통해 시청 기록을 생성하고 조회하도록 구현