### PR TITLE
AuthenticationThreadLocal 및 Filter에 인증 설정 추가

### DIFF
--- a/src/main/java/com/vidcentral/global/auth/AuthenticationThreadLocal.java
+++ b/src/main/java/com/vidcentral/global/auth/AuthenticationThreadLocal.java
@@ -1,0 +1,24 @@
+package com.vidcentral.global.auth;
+
+import com.vidcentral.api.domain.auth.entity.AuthMember;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class AuthenticationThreadLocal {
+
+	private static final ThreadLocal<AuthMember> authMemberHolder = new ThreadLocal<>();
+
+	public static void saveAuthMemberHolder(AuthMember authMember) {
+		AuthenticationThreadLocal.authMemberHolder.set(authMember);
+	}
+
+	public static AuthMember searchAuthMemberHolder() {
+		return authMemberHolder.get();
+	}
+
+	public static void removeAuthMemberHolder() {
+		authMemberHolder.remove();
+	}
+}


### PR DESCRIPTION
## AuthenticationThreadLocal 구현
- 인증된 사용자 정보를 ThreadLocal에 저장, 검색 및 삭제하는 메서드를 추가했습니다.

## AuthenticationFilter 설정 추가
- setAuthenticate(String accessToken) 메서드를 구현하여 JWT 토큰을 통해 인증된 사용자 정보를 추충하고, 이를 AuthenticationThreadLocal에 저장하도록 변경했습니다.
- 요청 처리 후 finally 블록에서 removeAuthMemberHolder를 호출하여 스레드 로컬에 저장된 인증 정보를 정리합니다.