### PR TITLE
댓글 생성, 조회, 수정, 삭제 API 구현

### DIFF
--- a/src/main/java/com/vidcentral/api/application/comment/CommentMapper.java
+++ b/src/main/java/com/vidcentral/api/application/comment/CommentMapper.java
@@ -1,0 +1,20 @@
+package com.vidcentral.api.application.comment;
+
+import com.vidcentral.api.domain.comment.entity.Comment;
+import com.vidcentral.api.domain.member.entity.Member;
+import com.vidcentral.api.domain.video.entity.Video;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CommentMapper {
+
+	public static Comment toComment(Member member, Video video, String content) {
+		return Comment.builder()
+			.member(member)
+			.video(video)
+			.content(content)
+			.build();
+	}
+}

--- a/src/main/java/com/vidcentral/api/application/comment/CommentMapper.java
+++ b/src/main/java/com/vidcentral/api/application/comment/CommentMapper.java
@@ -3,6 +3,7 @@ package com.vidcentral.api.application.comment;
 import com.vidcentral.api.domain.comment.entity.Comment;
 import com.vidcentral.api.domain.member.entity.Member;
 import com.vidcentral.api.domain.video.entity.Video;
+import com.vidcentral.api.dto.response.comment.CommentListResponse;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -15,6 +16,13 @@ public class CommentMapper {
 			.member(member)
 			.video(video)
 			.content(content)
+			.build();
+	}
+
+	public static CommentListResponse toCommentListResponse(Comment comment) {
+		return CommentListResponse.builder()
+			.nickname(comment.getMember().getNickname())
+			.content(comment.getContent())
 			.build();
 	}
 }

--- a/src/main/java/com/vidcentral/api/application/comment/CommentMapper.java
+++ b/src/main/java/com/vidcentral/api/application/comment/CommentMapper.java
@@ -3,7 +3,7 @@ package com.vidcentral.api.application.comment;
 import com.vidcentral.api.domain.comment.entity.Comment;
 import com.vidcentral.api.domain.member.entity.Member;
 import com.vidcentral.api.domain.video.entity.Video;
-import com.vidcentral.api.dto.response.comment.CommentListResponse;
+import com.vidcentral.api.dto.response.comment.CommentResponse;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -19,8 +19,8 @@ public class CommentMapper {
 			.build();
 	}
 
-	public static CommentListResponse toCommentListResponse(Comment comment) {
-		return CommentListResponse.builder()
+	public static CommentResponse toCommentResponse(Comment comment) {
+		return CommentResponse.builder()
 			.nickname(comment.getMember().getNickname())
 			.content(comment.getContent())
 			.build();

--- a/src/main/java/com/vidcentral/api/application/comment/CommentReadService.java
+++ b/src/main/java/com/vidcentral/api/application/comment/CommentReadService.java
@@ -1,0 +1,24 @@
+package com.vidcentral.api.application.comment;
+
+import static com.vidcentral.global.error.model.ErrorMessage.*;
+
+import org.springframework.stereotype.Service;
+
+import com.vidcentral.api.domain.comment.entity.Comment;
+import com.vidcentral.api.domain.comment.repository.CommentRepository;
+import com.vidcentral.api.domain.video.entity.Video;
+import com.vidcentral.global.error.exception.NotFoundException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CommentReadService {
+
+	private final CommentRepository commentRepository;
+
+	public Comment findComment(Video video) {
+		return commentRepository.findCommentByVideo(video)
+			.orElseThrow(() -> new NotFoundException(FAILED_VIDEO_NOT_FOUND_ERROR));
+	}
+}

--- a/src/main/java/com/vidcentral/api/application/comment/CommentReadService.java
+++ b/src/main/java/com/vidcentral/api/application/comment/CommentReadService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import com.vidcentral.api.domain.comment.entity.Comment;
 import com.vidcentral.api.domain.comment.repository.CommentRepository;
 import com.vidcentral.api.domain.video.entity.Video;
+import com.vidcentral.global.error.exception.BadRequestException;
 import com.vidcentral.global.error.exception.NotFoundException;
 
 import lombok.RequiredArgsConstructor;
@@ -20,5 +21,11 @@ public class CommentReadService {
 	public Comment findComment(Video video) {
 		return commentRepository.findCommentByVideo(video)
 			.orElseThrow(() -> new NotFoundException(FAILED_VIDEO_NOT_FOUND_ERROR));
+	}
+
+	public void validateMemberHasAccess(String commentOwnerEmail, String authMemberEmail) {
+		if (!commentOwnerEmail.equals(authMemberEmail)) {
+			throw new BadRequestException(FAILED_INVALID_COMMENT_ACCESS_ERROR);
+		}
 	}
 }

--- a/src/main/java/com/vidcentral/api/application/comment/CommentService.java
+++ b/src/main/java/com/vidcentral/api/application/comment/CommentService.java
@@ -13,7 +13,7 @@ import com.vidcentral.api.domain.comment.repository.CommentRepository;
 import com.vidcentral.api.domain.member.entity.Member;
 import com.vidcentral.api.domain.video.entity.Video;
 import com.vidcentral.api.dto.request.comment.UploadCommentRequest;
-import com.vidcentral.api.dto.response.comment.CommentListResponse;
+import com.vidcentral.api.dto.response.comment.CommentResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -24,6 +24,7 @@ public class CommentService {
 
 	private final MemberReadService memberReadService;
 	private final VideoReadService videoReadService;
+	private final CommentReadService commentReadService;
 	private final CommentRepository commentRepository;
 
 	@Transactional
@@ -35,12 +36,19 @@ public class CommentService {
 		commentRepository.save(comment);
 	}
 
-	public List<CommentListResponse> searchAllComments(Long videoId) {
+	public List<CommentResponse> searchAllComments(Long videoId) {
 		final Video video = videoReadService.findVideo(videoId);
 		final List<Comment> comments = commentRepository.findCommentsByVideo(video);
 
 		return comments.stream()
-			.map(CommentMapper::toCommentListResponse)
+			.map(CommentMapper::toCommentResponse)
 			.toList();
+	}
+
+	public CommentResponse searchComment(Long videoId) {
+		final Video video = videoReadService.findVideo(videoId);
+		final Comment comment = commentReadService.findComment(video);
+
+		return CommentMapper.toCommentResponse(comment);
 	}
 }

--- a/src/main/java/com/vidcentral/api/application/comment/CommentService.java
+++ b/src/main/java/com/vidcentral/api/application/comment/CommentService.java
@@ -63,4 +63,14 @@ public class CommentService {
 		commentReadService.validateMemberHasAccess(comment.getMember().getEmail(), loginMember.getEmail());
 		commentWriteService.updateComment(comment, updateCommentRequest);
 	}
+
+	@Transactional
+	public void deleteComment(AuthMember authMember, Long videoId) {
+		final Member loginMember = memberReadService.findMember(authMember.email());
+		final Video video = videoReadService.findVideo(videoId);
+		final Comment comment = commentReadService.findComment(video);
+
+		commentReadService.validateMemberHasAccess(comment.getMember().getEmail(), loginMember.getEmail());
+		commentWriteService.deleteComment(comment);
+	}
 }

--- a/src/main/java/com/vidcentral/api/application/comment/CommentService.java
+++ b/src/main/java/com/vidcentral/api/application/comment/CommentService.java
@@ -1,0 +1,34 @@
+package com.vidcentral.api.application.comment;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.vidcentral.api.application.member.MemberReadService;
+import com.vidcentral.api.application.video.VideoReadService;
+import com.vidcentral.api.domain.auth.entity.AuthMember;
+import com.vidcentral.api.domain.comment.entity.Comment;
+import com.vidcentral.api.domain.comment.repository.CommentRepository;
+import com.vidcentral.api.domain.member.entity.Member;
+import com.vidcentral.api.domain.video.entity.Video;
+import com.vidcentral.api.dto.request.comment.UploadCommentRequest;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommentService {
+
+	private final MemberReadService memberReadService;
+	private final VideoReadService videoReadService;
+	private final CommentRepository commentRepository;
+
+	@Transactional
+	public void uploadComment(AuthMember authMember, Long videoId, UploadCommentRequest uploadCommentRequest) {
+		final Member member = memberReadService.findMember(authMember.email());
+		final Video video = videoReadService.findVideo(videoId);
+
+		final Comment comment = CommentMapper.toComment(member, video, uploadCommentRequest.content());
+		commentRepository.save(comment);
+	}
+}

--- a/src/main/java/com/vidcentral/api/application/comment/CommentService.java
+++ b/src/main/java/com/vidcentral/api/application/comment/CommentService.java
@@ -47,13 +47,6 @@ public class CommentService {
 			.toList();
 	}
 
-	public CommentResponse searchComment(Long videoId) {
-		final Video video = videoReadService.findVideo(videoId);
-		final Comment comment = commentReadService.findComment(video);
-
-		return CommentMapper.toCommentResponse(comment);
-	}
-
 	@Transactional
 	public void updateComment(AuthMember authMember, Long videoId, UpdateCommentRequest updateCommentRequest) {
 		final Member loginMember = memberReadService.findMember(authMember.email());

--- a/src/main/java/com/vidcentral/api/application/comment/CommentService.java
+++ b/src/main/java/com/vidcentral/api/application/comment/CommentService.java
@@ -12,6 +12,7 @@ import com.vidcentral.api.domain.comment.entity.Comment;
 import com.vidcentral.api.domain.comment.repository.CommentRepository;
 import com.vidcentral.api.domain.member.entity.Member;
 import com.vidcentral.api.domain.video.entity.Video;
+import com.vidcentral.api.dto.request.comment.UpdateCommentRequest;
 import com.vidcentral.api.dto.request.comment.UploadCommentRequest;
 import com.vidcentral.api.dto.response.comment.CommentResponse;
 
@@ -25,6 +26,7 @@ public class CommentService {
 	private final MemberReadService memberReadService;
 	private final VideoReadService videoReadService;
 	private final CommentReadService commentReadService;
+	private final CommentWriteService commentWriteService;
 	private final CommentRepository commentRepository;
 
 	@Transactional
@@ -33,7 +35,7 @@ public class CommentService {
 		final Video video = videoReadService.findVideo(videoId);
 
 		final Comment comment = CommentMapper.toComment(loginMember, video, uploadCommentRequest.content());
-		commentRepository.save(comment);
+		commentWriteService.saveComment(comment);
 	}
 
 	public List<CommentResponse> searchAllComments(Long videoId) {
@@ -50,5 +52,15 @@ public class CommentService {
 		final Comment comment = commentReadService.findComment(video);
 
 		return CommentMapper.toCommentResponse(comment);
+	}
+
+	@Transactional
+	public void updateComment(AuthMember authMember, Long videoId, UpdateCommentRequest updateCommentRequest) {
+		final Member loginMember = memberReadService.findMember(authMember.email());
+		final Video video = videoReadService.findVideo(videoId);
+		final Comment comment = commentReadService.findComment(video);
+
+		commentReadService.validateMemberHasAccess(comment.getMember().getEmail(), loginMember.getEmail());
+		commentWriteService.updateComment(comment, updateCommentRequest);
 	}
 }

--- a/src/main/java/com/vidcentral/api/application/comment/CommentService.java
+++ b/src/main/java/com/vidcentral/api/application/comment/CommentService.java
@@ -1,5 +1,7 @@
 package com.vidcentral.api.application.comment;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,6 +13,7 @@ import com.vidcentral.api.domain.comment.repository.CommentRepository;
 import com.vidcentral.api.domain.member.entity.Member;
 import com.vidcentral.api.domain.video.entity.Video;
 import com.vidcentral.api.dto.request.comment.UploadCommentRequest;
+import com.vidcentral.api.dto.response.comment.CommentListResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,10 +28,19 @@ public class CommentService {
 
 	@Transactional
 	public void uploadComment(AuthMember authMember, Long videoId, UploadCommentRequest uploadCommentRequest) {
-		final Member member = memberReadService.findMember(authMember.email());
+		final Member loginMember = memberReadService.findMember(authMember.email());
 		final Video video = videoReadService.findVideo(videoId);
 
-		final Comment comment = CommentMapper.toComment(member, video, uploadCommentRequest.content());
+		final Comment comment = CommentMapper.toComment(loginMember, video, uploadCommentRequest.content());
 		commentRepository.save(comment);
+	}
+
+	public List<CommentListResponse> searchAllComments(Long videoId) {
+		final Video video = videoReadService.findVideo(videoId);
+		final List<Comment> comments = commentRepository.findCommentsByVideo(video);
+
+		return comments.stream()
+			.map(CommentMapper::toCommentListResponse)
+			.toList();
 	}
 }

--- a/src/main/java/com/vidcentral/api/application/comment/CommentWriteService.java
+++ b/src/main/java/com/vidcentral/api/application/comment/CommentWriteService.java
@@ -1,0 +1,24 @@
+package com.vidcentral.api.application.comment;
+
+import org.springframework.stereotype.Service;
+
+import com.vidcentral.api.domain.comment.entity.Comment;
+import com.vidcentral.api.domain.comment.repository.CommentRepository;
+import com.vidcentral.api.dto.request.comment.UpdateCommentRequest;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CommentWriteService {
+
+	private final CommentRepository commentRepository;
+
+	public void saveComment(Comment comment) {
+		commentRepository.save(comment);
+	}
+
+	public void updateComment(Comment comment, UpdateCommentRequest updateCommentRequest) {
+		comment.updateContent(updateCommentRequest.content());
+	}
+}

--- a/src/main/java/com/vidcentral/api/application/comment/CommentWriteService.java
+++ b/src/main/java/com/vidcentral/api/application/comment/CommentWriteService.java
@@ -21,4 +21,8 @@ public class CommentWriteService {
 	public void updateComment(Comment comment, UpdateCommentRequest updateCommentRequest) {
 		comment.updateContent(updateCommentRequest.content());
 	}
+
+	public void deleteComment(Comment comment) {
+		commentRepository.delete(comment);
+	}
 }

--- a/src/main/java/com/vidcentral/api/application/member/MemberMapper.java
+++ b/src/main/java/com/vidcentral/api/application/member/MemberMapper.java
@@ -22,7 +22,6 @@ public final class MemberMapper {
 		return MemberInfoResponse.builder()
 			.nickname(member.getNickname())
 			.introduce(member.getIntroduce())
-			.profileImage(member.getProfileImage())
 			.build();
 	}
 }

--- a/src/main/java/com/vidcentral/api/application/video/VideoService.java
+++ b/src/main/java/com/vidcentral/api/application/video/VideoService.java
@@ -13,7 +13,6 @@ import com.vidcentral.api.application.member.MemberReadService;
 import com.vidcentral.api.domain.auth.entity.AuthMember;
 import com.vidcentral.api.domain.member.entity.Member;
 import com.vidcentral.api.domain.video.entity.Video;
-import com.vidcentral.api.domain.video.repository.VideoRepository;
 import com.vidcentral.api.dto.request.video.UpdateVideoRequest;
 import com.vidcentral.api.dto.request.video.UploadVideoRequest;
 import com.vidcentral.api.dto.response.video.VideoDetailResponse;
@@ -31,7 +30,6 @@ public class VideoService {
 	private final MemberReadService memberReadService;
 	private final VideoWriteService videoWriteService;
 	private final VideoReadService videoReadService;
-	private final VideoRepository videoRepository;
 
 	@Transactional
 	public Video uploadVideo(AuthMember authMember, UploadVideoRequest uploadVideoRequest, MultipartFile newVideoURL) {
@@ -39,9 +37,9 @@ public class VideoService {
 		final Member loginMember = memberReadService.findMember(authMember.email());
 
 		videoReadService.validateTagCount(uploadVideoRequest.videoTags());
-		final Video video = VideoMapper.toVideo(loginMember, uploadVideoRequest, videoURL);
 
-		return videoRepository.save(video);
+		final Video video = VideoMapper.toVideo(loginMember, uploadVideoRequest, videoURL);
+		return videoWriteService.saveVideo(video);
 	}
 
 	public List<VideoListResponse> searchAllVideos() {
@@ -69,7 +67,8 @@ public class VideoService {
 	}
 
 	@Transactional
-	public void updateVideo(AuthMember authMember, Long videoId, UpdateVideoRequest updateVideoRequest, MultipartFile videoURL) {
+	public void updateVideo(AuthMember authMember, Long videoId, UpdateVideoRequest updateVideoRequest,
+		MultipartFile videoURL) {
 		final Member loginMember = memberReadService.findMember(authMember.email());
 		final Video video = videoReadService.findVideo(videoId);
 
@@ -87,6 +86,6 @@ public class VideoService {
 		videoReadService.validateMemberHasAccess(video.getMember().getEmail(), loginMember.getEmail());
 
 		mediaService.deleteVideo(video.getVideoURL());
-		videoRepository.delete(video);
+		videoWriteService.deleteVideo(video);
 	}
 }

--- a/src/main/java/com/vidcentral/api/application/video/VideoWriteService.java
+++ b/src/main/java/com/vidcentral/api/application/video/VideoWriteService.java
@@ -3,6 +3,7 @@ package com.vidcentral.api.application.video;
 import org.springframework.stereotype.Service;
 
 import com.vidcentral.api.domain.video.entity.Video;
+import com.vidcentral.api.domain.video.repository.VideoRepository;
 import com.vidcentral.api.dto.request.video.UpdateVideoRequest;
 
 import lombok.RequiredArgsConstructor;
@@ -11,11 +12,21 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class VideoWriteService {
 
+	private final VideoRepository videoRepository;
+
+	public Video saveVideo(Video video) {
+		return videoRepository.save(video);
+	}
+
 	public void updateVideo(Video video, UpdateVideoRequest updateVideoRequest, String newVideoURL) {
 		video.updateTitle(updateVideoRequest.title());
 		video.updateDescription(updateVideoRequest.description());
 		video.updateVideoURL(newVideoURL);
 		video.updateVideoTags(updateVideoRequest.videoTags());
+	}
+
+	public void deleteVideo(Video video) {
+		videoRepository.delete(video);
 	}
 
 	public void incrementVideoViews(Video video) {

--- a/src/main/java/com/vidcentral/api/domain/comment/entity/Comment.java
+++ b/src/main/java/com/vidcentral/api/domain/comment/entity/Comment.java
@@ -1,5 +1,7 @@
 package com.vidcentral.api.domain.comment.entity;
 
+import static java.util.Objects.*;
+
 import com.vidcentral.api.domain.member.entity.Member;
 import com.vidcentral.api.domain.video.entity.Video;
 import com.vidcentral.global.common.entity.BaseTimeEntity;
@@ -45,5 +47,9 @@ public class Comment extends BaseTimeEntity {
 		this.video = video;
 		this.member = member;
 		this.content = content;
+	}
+
+	public void updateContent(String content) {
+		this.content = requireNonNull(content, this.content);
 	}
 }

--- a/src/main/java/com/vidcentral/api/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/vidcentral/api/domain/comment/repository/CommentRepository.java
@@ -1,10 +1,15 @@
 package com.vidcentral.api.domain.comment.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import com.vidcentral.api.domain.comment.entity.Comment;
+import com.vidcentral.api.domain.video.entity.Video;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+	List<Comment> findCommentsByVideo(Video video);
 }

--- a/src/main/java/com/vidcentral/api/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/vidcentral/api/domain/comment/repository/CommentRepository.java
@@ -1,6 +1,7 @@
 package com.vidcentral.api.domain.comment.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -10,6 +11,8 @@ import com.vidcentral.api.domain.video.entity.Video;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+	Optional<Comment> findCommentByVideo(Video video);
 
 	List<Comment> findCommentsByVideo(Video video);
 }

--- a/src/main/java/com/vidcentral/api/dto/request/comment/UpdateCommentRequest.java
+++ b/src/main/java/com/vidcentral/api/dto/request/comment/UpdateCommentRequest.java
@@ -1,0 +1,9 @@
+package com.vidcentral.api.dto.request.comment;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateCommentRequest(
+	@NotBlank(message = "댓글 내용은 필수 입력 항목입니다.")
+	String content
+) {
+}

--- a/src/main/java/com/vidcentral/api/dto/request/comment/UploadCommentRequest.java
+++ b/src/main/java/com/vidcentral/api/dto/request/comment/UploadCommentRequest.java
@@ -1,0 +1,11 @@
+package com.vidcentral.api.dto.request.comment;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+@Builder
+public record UploadCommentRequest(
+	@NotBlank(message = "댓글 내용은 필수 입력 항목입니다.")
+	String content
+) {
+}

--- a/src/main/java/com/vidcentral/api/dto/response/comment/CommentListResponse.java
+++ b/src/main/java/com/vidcentral/api/dto/response/comment/CommentListResponse.java
@@ -1,0 +1,10 @@
+package com.vidcentral.api.dto.response.comment;
+
+import lombok.Builder;
+
+@Builder
+public record CommentListResponse(
+	String nickname,
+	String content
+) {
+}

--- a/src/main/java/com/vidcentral/api/dto/response/comment/CommentResponse.java
+++ b/src/main/java/com/vidcentral/api/dto/response/comment/CommentResponse.java
@@ -3,7 +3,7 @@ package com.vidcentral.api.dto.response.comment;
 import lombok.Builder;
 
 @Builder
-public record CommentListResponse(
+public record CommentResponse(
 	String nickname,
 	String content
 ) {

--- a/src/main/java/com/vidcentral/api/dto/response/member/MemberInfoResponse.java
+++ b/src/main/java/com/vidcentral/api/dto/response/member/MemberInfoResponse.java
@@ -5,7 +5,6 @@ import lombok.Builder;
 @Builder
 public record MemberInfoResponse(
 	String nickname,
-	String introduce,
-	String profileImage
+	String introduce
 ) {
 }

--- a/src/main/java/com/vidcentral/api/presentation/comment/CommentController.java
+++ b/src/main/java/com/vidcentral/api/presentation/comment/CommentController.java
@@ -1,0 +1,115 @@
+package com.vidcentral.api.presentation.comment;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.vidcentral.api.application.comment.CommentService;
+import com.vidcentral.api.domain.auth.entity.AuthMember;
+import com.vidcentral.api.dto.request.comment.UpdateCommentRequest;
+import com.vidcentral.api.dto.request.comment.UploadCommentRequest;
+import com.vidcentral.api.dto.response.comment.CommentResponse;
+import com.vidcentral.global.auth.annotation.AuthenticationMember;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/comments")
+public class CommentController {
+
+	private final CommentService commentService;
+
+	@PostMapping("/upload/{videoId}")
+	@ResponseStatus(HttpStatus.CREATED)
+	@Operation(
+		summary = "댓글 업로드 API",
+		description = "사용자가 댓글을 업로드합니다."
+	)
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "성공 - 댓글 업로드, 댓글 정보가 생성되었습니다."),
+		@ApiResponse(responseCode = "400", description = "실패 - 잘못된 요청, 필수 입력값이 누락되었거나 형식이 올바르지 않습니다."),
+		@ApiResponse(responseCode = "404", description = "실패 - 해당 비디오를 찾을 수 없습니다."),
+		@ApiResponse(responseCode = "500", description = "실패 - 서버 오류, 요청 처리 중 문제가 발생했습니다.")
+	})
+	public ResponseEntity<String> uploadComment(
+		@AuthenticationMember AuthMember authMember,
+		@PathVariable Long videoId,
+		@Valid @RequestPart(required = false) UploadCommentRequest uploadCommentRequest) {
+
+		commentService.uploadComment(authMember, videoId, uploadCommentRequest);
+		return ResponseEntity.ok().body("성공적으로 댓글 정보를 업로드했습니다.");
+	}
+
+	@GetMapping("/{videoId}")
+	@ResponseStatus(HttpStatus.OK)
+	@Operation(
+		summary = "모든 댓글 조회 API",
+		description = "모든 댓글을 조회합니다."
+	)
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "성공 - 모든 댓글 조회, 모든 댓글 정보를 조회했습니다."),
+		@ApiResponse(responseCode = "404", description = "실패 - 해당 회원을 찾을 수 없습니다."),
+		@ApiResponse(responseCode = "500", description = "실패 - 서버 오류, 요청 처리 중 문제가 발생했습니다.")
+	})
+	public ResponseEntity<List<CommentResponse>> searchAllComments(@PathVariable Long videoId) {
+		return ResponseEntity.ok().body(commentService.searchAllComments(videoId));
+	}
+
+	@PutMapping("/update/{videoId}")
+	@ResponseStatus(HttpStatus.OK)
+	@Operation(
+		summary = "댓글 수정 API",
+		description = "사용자가 댓글 내용을 업데이트합니다."
+	)
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "성공 - 댓글 수정, 댓글 정보가 업데이트되었습니다."),
+		@ApiResponse(responseCode = "400", description = "실패 - 잘못된 요청, 필수 입력값이 누락되었거나 형식이 올바르지 않습니다."),
+		@ApiResponse(responseCode = "404", description = "실패 - 해당 비디오를 찾을 수 없습니다."),
+		@ApiResponse(responseCode = "409", description = "실패 - 유효하지 않은 댓글입니다."),
+		@ApiResponse(responseCode = "500", description = "실패 - 서버 오류, 요청 처리 중 문제가 발생했습니다.")
+	})
+	public ResponseEntity<String> updateComment(
+		@AuthenticationMember AuthMember authMember,
+		@PathVariable Long videoId,
+		@Valid @RequestPart(required = false) UpdateCommentRequest updateCommentRequest) {
+
+		commentService.updateComment(authMember, videoId, updateCommentRequest);
+		return ResponseEntity.ok().body("성공적으로 댓글 정보를 업데이트했습니다.");
+	}
+
+	@DeleteMapping("/delete/{videoId}")
+	@ResponseStatus(HttpStatus.OK)
+	@Operation(
+		summary = "댓글 삭제 API",
+		description = "사용자가 댓글을 삭제합니다."
+	)
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "성공 - 댓글 삭제, 댓글 정보가 삭제되었습니다."),
+		@ApiResponse(responseCode = "400", description = "실패 - 잘못된 요청, 필수 입력값이 누락되었거나 형식이 올바르지 않습니다."),
+		@ApiResponse(responseCode = "404", description = "실패 - 해당 비디오를 찾을 수 없습니다."),
+		@ApiResponse(responseCode = "409", description = "실패 - 유효하지 않은 댓글입니다."),
+		@ApiResponse(responseCode = "500", description = "실패 - 서버 오류, 요청 처리 중 문제가 발생했습니다.")
+	})
+	public ResponseEntity<String> deleteComment(
+		@AuthenticationMember AuthMember authMember,
+		@PathVariable Long videoId) {
+
+		commentService.deleteComment(authMember, videoId);
+		return ResponseEntity.ok().body("성공적으로 댓글 정보를 삭제했습니다.");
+	}
+}

--- a/src/main/java/com/vidcentral/global/error/model/ErrorMessage.java
+++ b/src/main/java/com/vidcentral/global/error/model/ErrorMessage.java
@@ -14,6 +14,7 @@ public enum ErrorMessage {
 	FAILED_INVALID_IMAGE_EXTENSION_ERROR("[❎ ERROR] 유효하지 않은 이미지 확장자입니다."),
 	FAILED_INVALID_VIDEO_ERROR("[❎ ERROR] 유효하지 않은 비디오 파일입니다."),
 	FAILED_INVALID_VIDEO_ACCESS_ERROR("[❎ ERROR] 유효하지 않은 비디오 접근입니다."),
+	FAILED_INVALID_COMMENT_ACCESS_ERROR("[❎ ERROR] 유효하지 않은 댓글 접근입니다."),
 	FAILED_MAX_TAG_COUNT_ERROR("[❎ ERROR] 태그는 최대 3개까지 설정할 수 있습니다."),
 	FAILED_S3_RESIZE_ERROR("[❎ ERROR] S3 이미지 리사이즈에 실패했습니다."),
 	FAILED_UNAUTHORIZED_MEMBER_ERROR("[❎ ERROR] 해당 사용자는 인증되지 않은 사용자입니다."),


### PR DESCRIPTION
## 댓글 생성
- 댓글 작성 시, uploadComment 메서드를 통해 인증된 사용자의 정보를 기반으로 댓글을 저장합니다.
- CommentWriteService에 댓글 생성 기능을 추가했습니다.

## 댓글 조회
- searchAllComments 메서드를 통해 특정 비디오에 대한 모든 댓글을 조회할 수 있습니다.
- CommentReadService에 댓글 조회 및 검증 로직을 추가했습니다.

## 댓글 수정
- updateComment 메서드는 사용자가 자신의 댓글을 수정할 수 있도록 합니다.
- CommentWriteService에 댓글 수정 기능을 추가했습니다.

## 댓글 삭제
- deleteComment 메서드는 사용자가 자신의 댓글을 삭제할 수 있도록 합니다.
- CommentWriteService에 댓글 삭제 기능을 추가했습니다.