### PR TITLE
데이터베이스 인덱스 추가 작업

### DIFF
--- a/src/main/java/com/vidcentral/api/domain/comment/entity/Comment.java
+++ b/src/main/java/com/vidcentral/api/domain/comment/entity/Comment.java
@@ -12,6 +12,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -22,7 +23,10 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "COMMENT")
+@Table(name = "COMMENTS",
+	indexes = {
+		@Index(name = "IDX_MEMBER_VIDEO", columnList = "member_id, video_id", unique = true)
+	})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Comment extends BaseTimeEntity {
 

--- a/src/main/java/com/vidcentral/api/domain/like/entity/Like.java
+++ b/src/main/java/com/vidcentral/api/domain/like/entity/Like.java
@@ -10,6 +10,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -20,7 +21,10 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "LIKE")
+@Table(name = "LIKES",
+	indexes = {
+		@Index(name = "IDX_MEMBER_VIDEO", columnList = "member_id, video_id", unique = true)
+	})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Like extends BaseTimeEntity {
 

--- a/src/main/java/com/vidcentral/api/domain/member/entity/Member.java
+++ b/src/main/java/com/vidcentral/api/domain/member/entity/Member.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -19,7 +20,11 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "MEMBER")
+@Table(name = "MEMBERS",
+	indexes = {
+		@Index(name = "IDX_MEMBER_EMAIL", columnList = "email", unique = true),
+		@Index(name = "IDX_MEMBER_NICKNAME", columnList = "nickname", unique = true)
+	})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseTimeEntity {
 

--- a/src/main/java/com/vidcentral/api/domain/video/entity/Video.java
+++ b/src/main/java/com/vidcentral/api/domain/video/entity/Video.java
@@ -31,7 +31,8 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "VIDEOS",
 	indexes = {
-		@Index(name = "IDX_VIDEO_ID", columnList = "video_id", unique = true)
+		@Index(name = "IDX_VIDEO_ID", columnList = "video_id", unique = true),
+		@Index(name = "IDX_VIDEO_TITLE", columnList = "title")
 	})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Video extends BaseTimeEntity {
@@ -58,7 +59,11 @@ public class Video extends BaseTimeEntity {
 	private Long views = 0L;
 
 	@ElementCollection(targetClass = VideoTag.class)
-	@CollectionTable(name = "video_tags", joinColumns = @JoinColumn(name = "video_id"))
+	@CollectionTable(
+		name = "video_tags",
+		joinColumns = @JoinColumn(name = "video_id"),
+		indexes = @Index(name = "IDX_VIDEO_TAGS", columnList = "video_tags")
+	)
 	@Column(name = "video_tags")
 	@Enumerated(EnumType.STRING)
 	private Set<VideoTag> videoTags = new HashSet<>();

--- a/src/main/java/com/vidcentral/api/domain/video/entity/Video.java
+++ b/src/main/java/com/vidcentral/api/domain/video/entity/Video.java
@@ -18,6 +18,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -28,7 +29,10 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "VIDEO")
+@Table(name = "VIDEOS",
+	indexes = {
+		@Index(name = "IDX_VIDEO_ID", columnList = "video_id", unique = true)
+	})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Video extends BaseTimeEntity {
 

--- a/src/main/java/com/vidcentral/api/domain/viewHistory/entity/ViewHistory.java
+++ b/src/main/java/com/vidcentral/api/domain/viewHistory/entity/ViewHistory.java
@@ -11,6 +11,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -21,7 +22,10 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "VIEW_HISTORY")
+@Table(name = "VIEW_HISTORIES",
+	indexes = {
+		@Index(name = "IDX_MEMBER_VIDEO", columnList = "member_id, video_id", unique = true)
+	})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ViewHistory {
 


### PR DESCRIPTION
데이터베이스 성능을 향상시키기 위해 자주 조회되는 필드에 대한 인덱스를 추가했습니다.

Member 엔티티에서 이메일과 닉네임에 대한 인덱스를 추가했습니다.
Video 엔티티에서 비디오 ID, 비디오 제목, 비디오 태그에 대한 인덱스를 추가해 조회 성능을 개선했습니다.
Comment 엔티티에서 사용자 ID와 비디오 ID에 대한 인덱스를 추가해 댓글 조회 성능을 향상했습니다.
ViewHistory 엔티티에서 사용자 ID와 비디오 ID에 대한 인덱스를 추가해 시청 기록 조회 성능을 개선했습니다.
Like 엔티티에서 사용자 ID와 비디오 ID에 대한 인덱스를 추가해 좋아요 조회 성능을 최적화했습니다.