### PR TITLE
비디오 및 댓글 목록 조회 로직 페이징 처리

### DIFF
--- a/src/main/java/com/vidcentral/api/application/comment/CommentMapper.java
+++ b/src/main/java/com/vidcentral/api/application/comment/CommentMapper.java
@@ -3,7 +3,7 @@ package com.vidcentral.api.application.comment;
 import com.vidcentral.api.domain.comment.entity.Comment;
 import com.vidcentral.api.domain.member.entity.Member;
 import com.vidcentral.api.domain.video.entity.Video;
-import com.vidcentral.api.dto.response.comment.CommentResponse;
+import com.vidcentral.api.dto.response.comment.CommentListResponse;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -19,8 +19,8 @@ public class CommentMapper {
 			.build();
 	}
 
-	public static CommentResponse toCommentResponse(Comment comment) {
-		return CommentResponse.builder()
+	public static CommentListResponse toCommentListResponse(Comment comment) {
+		return CommentListResponse.builder()
 			.nickname(comment.getMember().getNickname())
 			.content(comment.getContent())
 			.build();

--- a/src/main/java/com/vidcentral/api/application/comment/CommentReadService.java
+++ b/src/main/java/com/vidcentral/api/application/comment/CommentReadService.java
@@ -12,7 +12,7 @@ import com.vidcentral.api.application.page.PageMapper;
 import com.vidcentral.api.domain.comment.entity.Comment;
 import com.vidcentral.api.domain.comment.repository.CommentRepository;
 import com.vidcentral.api.domain.video.entity.Video;
-import com.vidcentral.api.dto.response.comment.CommentResponse;
+import com.vidcentral.api.dto.response.comment.CommentListResponse;
 import com.vidcentral.api.dto.response.page.PageResponse;
 import com.vidcentral.global.error.exception.BadRequestException;
 import com.vidcentral.global.error.exception.NotFoundException;
@@ -30,15 +30,15 @@ public class CommentReadService {
 			.orElseThrow(() -> new NotFoundException(FAILED_VIDEO_NOT_FOUND_ERROR));
 	}
 
-	public PageResponse<CommentResponse> findAllCommentsByVideo(Video video, Pageable pageable) {
+	public PageResponse<CommentListResponse> findAllCommentsByVideo(Video video, Pageable pageable) {
 		final Page<Comment> comments = commentRepository.findCommentsByVideo(video, pageable);
 
-		final List<CommentResponse> commentResponses = comments.getContent().stream()
-			.map(CommentMapper::toCommentResponse)
+		final List<CommentListResponse> commentListResponses = comments.getContent().stream()
+			.map(CommentMapper::toCommentListResponse)
 			.toList();
 
 		return PageMapper.toPageResponse(
-			PageMapper.toPageImpl(commentResponses, pageable, comments.getTotalElements()));
+			PageMapper.toPageImpl(commentListResponses, pageable, comments.getTotalElements()));
 	}
 
 	public void validateMemberHasAccess(String commentOwnerEmail, String authMemberEmail) {

--- a/src/main/java/com/vidcentral/api/application/comment/CommentReadService.java
+++ b/src/main/java/com/vidcentral/api/application/comment/CommentReadService.java
@@ -2,11 +2,18 @@ package com.vidcentral.api.application.comment;
 
 import static com.vidcentral.global.error.model.ErrorMessage.*;
 
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import com.vidcentral.api.application.page.PageMapper;
 import com.vidcentral.api.domain.comment.entity.Comment;
 import com.vidcentral.api.domain.comment.repository.CommentRepository;
 import com.vidcentral.api.domain.video.entity.Video;
+import com.vidcentral.api.dto.response.comment.CommentResponse;
+import com.vidcentral.api.dto.response.page.PageResponse;
 import com.vidcentral.global.error.exception.BadRequestException;
 import com.vidcentral.global.error.exception.NotFoundException;
 
@@ -21,6 +28,17 @@ public class CommentReadService {
 	public Comment findComment(Video video) {
 		return commentRepository.findCommentByVideo(video)
 			.orElseThrow(() -> new NotFoundException(FAILED_VIDEO_NOT_FOUND_ERROR));
+	}
+
+	public PageResponse<CommentResponse> findAllCommentsByVideo(Video video, Pageable pageable) {
+		final Page<Comment> comments = commentRepository.findCommentsByVideo(video, pageable);
+
+		final List<CommentResponse> commentResponses = comments.getContent().stream()
+			.map(CommentMapper::toCommentResponse)
+			.toList();
+
+		return PageMapper.toPageResponse(
+			PageMapper.toPageImpl(commentResponses, pageable, comments.getTotalElements()));
 	}
 
 	public void validateMemberHasAccess(String commentOwnerEmail, String authMemberEmail) {

--- a/src/main/java/com/vidcentral/api/application/comment/CommentService.java
+++ b/src/main/java/com/vidcentral/api/application/comment/CommentService.java
@@ -12,7 +12,7 @@ import com.vidcentral.api.domain.member.entity.Member;
 import com.vidcentral.api.domain.video.entity.Video;
 import com.vidcentral.api.dto.request.comment.UpdateCommentRequest;
 import com.vidcentral.api.dto.request.comment.UploadCommentRequest;
-import com.vidcentral.api.dto.response.comment.CommentResponse;
+import com.vidcentral.api.dto.response.comment.CommentListResponse;
 import com.vidcentral.api.dto.response.page.PageResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -36,7 +36,7 @@ public class CommentService {
 		commentWriteService.saveComment(comment);
 	}
 
-	public PageResponse<CommentResponse> searchAllComments(Long videoId, int page, int size) {
+	public PageResponse<CommentListResponse> searchAllComments(Long videoId, int page, int size) {
 		final Video video = videoReadService.findVideo(videoId);
 		return commentReadService.findAllCommentsByVideo(video, PageRequest.of(page, size));
 	}

--- a/src/main/java/com/vidcentral/api/application/comment/CommentService.java
+++ b/src/main/java/com/vidcentral/api/application/comment/CommentService.java
@@ -1,7 +1,6 @@
 package com.vidcentral.api.application.comment;
 
-import java.util.List;
-
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -9,12 +8,12 @@ import com.vidcentral.api.application.member.MemberReadService;
 import com.vidcentral.api.application.video.VideoReadService;
 import com.vidcentral.api.domain.auth.entity.AuthMember;
 import com.vidcentral.api.domain.comment.entity.Comment;
-import com.vidcentral.api.domain.comment.repository.CommentRepository;
 import com.vidcentral.api.domain.member.entity.Member;
 import com.vidcentral.api.domain.video.entity.Video;
 import com.vidcentral.api.dto.request.comment.UpdateCommentRequest;
 import com.vidcentral.api.dto.request.comment.UploadCommentRequest;
 import com.vidcentral.api.dto.response.comment.CommentResponse;
+import com.vidcentral.api.dto.response.page.PageResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -27,7 +26,6 @@ public class CommentService {
 	private final VideoReadService videoReadService;
 	private final CommentReadService commentReadService;
 	private final CommentWriteService commentWriteService;
-	private final CommentRepository commentRepository;
 
 	@Transactional
 	public void uploadComment(AuthMember authMember, Long videoId, UploadCommentRequest uploadCommentRequest) {
@@ -38,13 +36,9 @@ public class CommentService {
 		commentWriteService.saveComment(comment);
 	}
 
-	public List<CommentResponse> searchAllComments(Long videoId) {
+	public PageResponse<CommentResponse> searchAllComments(Long videoId, int page, int size) {
 		final Video video = videoReadService.findVideo(videoId);
-		final List<Comment> comments = commentRepository.findCommentsByVideo(video);
-
-		return comments.stream()
-			.map(CommentMapper::toCommentResponse)
-			.toList();
+		return commentReadService.findAllCommentsByVideo(video, PageRequest.of(page, size));
 	}
 
 	@Transactional

--- a/src/main/java/com/vidcentral/api/application/member/MemberService.java
+++ b/src/main/java/com/vidcentral/api/application/member/MemberService.java
@@ -14,7 +14,7 @@ import com.vidcentral.api.domain.auth.entity.AuthMember;
 import com.vidcentral.api.domain.member.entity.Member;
 import com.vidcentral.api.dto.request.auth.LoginRequest;
 import com.vidcentral.api.dto.request.member.SignUpRequest;
-import com.vidcentral.api.dto.request.member.UpdateRequest;
+import com.vidcentral.api.dto.request.member.UpdateMemberRequest;
 import com.vidcentral.api.dto.response.auth.LoginResponse;
 import com.vidcentral.api.dto.response.member.MemberInfoResponse;
 
@@ -54,11 +54,13 @@ public class MemberService {
 	}
 
 	@Transactional
-	public void updateMemberInfo(AuthMember authMember, UpdateRequest updateRequest, MultipartFile profileImageURL) {
+	public void updateMemberInfo(AuthMember authMember, UpdateMemberRequest updateMemberRequest,
+		MultipartFile profileImageURL) {
+
 		final Member loginMember = memberReadService.findMember(authMember.email());
-		memberReadService.validateNicknameDuplication(updateRequest.nickname());
+		memberReadService.validateNicknameDuplication(updateMemberRequest.nickname());
 
 		String newProfileImageURL = mediaService.uploadImages(List.of(profileImageURL), PROFILE_IMAGE).get(0);
-		memberWriteService.changeMemberInfo(loginMember, updateRequest, newProfileImageURL);
+		memberWriteService.changeMemberInfo(loginMember, updateMemberRequest, newProfileImageURL);
 	}
 }

--- a/src/main/java/com/vidcentral/api/application/member/MemberWriteService.java
+++ b/src/main/java/com/vidcentral/api/application/member/MemberWriteService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 import com.vidcentral.api.domain.member.entity.Member;
 import com.vidcentral.api.domain.member.repository.MemberRepository;
 import com.vidcentral.api.dto.request.member.SignUpRequest;
-import com.vidcentral.api.dto.request.member.UpdateRequest;
+import com.vidcentral.api.dto.request.member.UpdateMemberRequest;
 
 import lombok.RequiredArgsConstructor;
 
@@ -21,9 +21,9 @@ public class MemberWriteService {
 		memberRepository.save(MemberMapper.toMember(signUpRequest, passwordEncoder.encode(signUpRequest.password())));
 	}
 
-	public void changeMemberInfo(Member member, UpdateRequest updateRequest, String newProfileImageURL) {
-		member.updateIntroduce(updateRequest.introduce());
-		member.updateNickname(updateRequest.nickname());
+	public void changeMemberInfo(Member member, UpdateMemberRequest updateMemberRequest, String newProfileImageURL) {
+		member.updateIntroduce(updateMemberRequest.introduce());
+		member.updateNickname(updateMemberRequest.nickname());
 		member.updateProfileImageURL(newProfileImageURL);
 	}
 }

--- a/src/main/java/com/vidcentral/api/application/page/PageMapper.java
+++ b/src/main/java/com/vidcentral/api/application/page/PageMapper.java
@@ -1,0 +1,30 @@
+package com.vidcentral.api.application.page;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import com.vidcentral.api.dto.response.page.PageResponse;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PageMapper {
+
+	public static <T> PageResponse<T> toPageResponse(Page<T> page) {
+		return PageResponse.<T>builder()
+			.content(page.getContent())
+			.pageIndex(page.getNumber())
+			.totalPages(page.getTotalPages())
+			.totalElements(page.getTotalElements())
+			.isLast(page.isLast())
+			.build();
+	}
+
+	public static <T> Page<T> toPageImpl(List<T> content, Pageable pageable, long total) {
+		return new PageImpl<>(content, pageable, total);
+	}
+}

--- a/src/main/java/com/vidcentral/api/application/video/VideoMapper.java
+++ b/src/main/java/com/vidcentral/api/application/video/VideoMapper.java
@@ -25,13 +25,12 @@ public class VideoMapper {
 			.build();
 	}
 
-	public static PageResponse<VideoListResponse> toPageResponse(Page<Video> page) {
-		return PageResponse.<VideoListResponse>builder()
-			.content(page.map(VideoMapper::toVideoListResponse).getContent())
-			.pageIndex(page.getNumber())
-			.totalPages(page.getTotalPages())
-			.totalElements(page.getTotalElements())
-			.isLast(page.isLast())
+	public static VideoListResponse toVideoListResponse(Video video) {
+		return VideoListResponse.builder()
+			.nickname(video.getMember().getNickname())
+			.title(video.getTitle())
+			.videoURL(video.getVideoURL())
+			.views(video.getViews())
 			.build();
 	}
 
@@ -40,15 +39,6 @@ public class VideoMapper {
 			.nickname(video.getMember().getNickname())
 			.title(video.getTitle())
 			.description(video.getDescription())
-			.videoURL(video.getVideoURL())
-			.views(video.getViews())
-			.build();
-	}
-
-	public static VideoListResponse toVideoListResponse(Video video) {
-		return VideoListResponse.builder()
-			.nickname(video.getMember().getNickname())
-			.title(video.getTitle())
 			.videoURL(video.getVideoURL())
 			.views(video.getViews())
 			.build();

--- a/src/main/java/com/vidcentral/api/application/video/VideoMapper.java
+++ b/src/main/java/com/vidcentral/api/application/video/VideoMapper.java
@@ -1,8 +1,11 @@
 package com.vidcentral.api.application.video;
 
+import org.springframework.data.domain.Page;
+
 import com.vidcentral.api.domain.member.entity.Member;
 import com.vidcentral.api.domain.video.entity.Video;
 import com.vidcentral.api.dto.request.video.UploadVideoRequest;
+import com.vidcentral.api.dto.response.page.PageResponse;
 import com.vidcentral.api.dto.response.video.VideoDetailResponse;
 import com.vidcentral.api.dto.response.video.VideoListResponse;
 
@@ -22,12 +25,13 @@ public class VideoMapper {
 			.build();
 	}
 
-	public static VideoListResponse toVideoListResponse(Video video) {
-		return VideoListResponse.builder()
-			.nickname(video.getMember().getNickname())
-			.title(video.getTitle())
-			.videoURL(video.getVideoURL())
-			.views(video.getViews())
+	public static PageResponse<VideoListResponse> toPageResponse(Page<Video> page) {
+		return PageResponse.<VideoListResponse>builder()
+			.content(page.map(VideoMapper::toVideoListResponse).getContent())
+			.pageIndex(page.getNumber())
+			.totalPages(page.getTotalPages())
+			.totalElements(page.getTotalElements())
+			.isLast(page.isLast())
 			.build();
 	}
 
@@ -36,6 +40,15 @@ public class VideoMapper {
 			.nickname(video.getMember().getNickname())
 			.title(video.getTitle())
 			.description(video.getDescription())
+			.videoURL(video.getVideoURL())
+			.views(video.getViews())
+			.build();
+	}
+
+	public static VideoListResponse toVideoListResponse(Video video) {
+		return VideoListResponse.builder()
+			.nickname(video.getMember().getNickname())
+			.title(video.getTitle())
 			.videoURL(video.getVideoURL())
 			.views(video.getViews())
 			.build();

--- a/src/main/java/com/vidcentral/api/application/video/VideoReadService.java
+++ b/src/main/java/com/vidcentral/api/application/video/VideoReadService.java
@@ -47,7 +47,8 @@ public class VideoReadService {
 		return videoRepository.findAll(pageable);
 	}
 
-	public PageResponse<VideoListResponse> findAllVideosByKeyword(SearchVideoRequest searchVideoRequest, Pageable pageable) {
+	public PageResponse<VideoListResponse> findAllVideosByKeyword(SearchVideoRequest searchVideoRequest,
+		Pageable pageable) {
 		final Set<Video> distinctVideos = findDistinctVideosByKeyword(searchVideoRequest.keyword(), pageable);
 
 		final List<VideoListResponse> videoListResponses = distinctVideos.stream()
@@ -82,12 +83,13 @@ public class VideoReadService {
 			.orElseThrow(() -> new BadRequestException(FAILED_INVALID_REQUEST_ERROR));
 	}
 
-	public List<VideoListResponse> findAllRecommendationVideos(Member member) {
+	public PageResponse<VideoListResponse> findAllRecommendationVideos(Member member, Pageable pageable) {
 		final Set<VideoTag> likedVideoTags = recommendationService.extractLikedVideoTags(member);
 		final Set<String> likedVideoTitles = recommendationService.extractLikedVideoTitle(member);
 		final Set<VideoTag> viewHistoryVideoTags = recommendationService.extractViewHistoryVideoTags(member);
 
-		return recommendationService.findRecommendationVideos(likedVideoTags, likedVideoTitles, viewHistoryVideoTags);
+		return recommendationService
+			.findRecommendationVideos(likedVideoTags, likedVideoTitles, viewHistoryVideoTags, pageable);
 	}
 
 	public void validateMemberHasAccess(String videoOwnerEmail, String authMemberEmail) {

--- a/src/main/java/com/vidcentral/api/application/video/VideoReadService.java
+++ b/src/main/java/com/vidcentral/api/application/video/VideoReadService.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import com.vidcentral.api.application.member.MemberReadService;
@@ -39,8 +41,8 @@ public class VideoReadService {
 			.orElseThrow(() -> new NotFoundException(FAILED_VIDEO_NOT_FOUND_ERROR));
 	}
 
-	public List<Video> findAllVideos() {
-		return videoRepository.findAll();
+	public Page<Video> findAllVideos(Pageable pageable) {
+		return videoRepository.findAll(pageable);
 	}
 
 	public List<Video> findAllVideosByTitle(String title) {

--- a/src/main/java/com/vidcentral/api/application/video/VideoReadService.java
+++ b/src/main/java/com/vidcentral/api/application/video/VideoReadService.java
@@ -11,7 +11,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import com.vidcentral.api.application.member.MemberReadService;
 import com.vidcentral.api.application.recommendation.RecommendationService;
 import com.vidcentral.api.application.viewHistory.ViewHistoryService;
 import com.vidcentral.api.domain.auth.entity.AuthMember;
@@ -32,7 +31,6 @@ public class VideoReadService {
 
 	private static final int MAX_TAG_COUNT = 3;
 
-	private final MemberReadService memberReadService;
 	private final ViewHistoryService viewHistoryService;
 	private final RecommendationService recommendationService;
 	private final VideoRepository videoRepository;
@@ -63,11 +61,6 @@ public class VideoReadService {
 
 	private Page<Video> findAllVideosByDescription(String description, Pageable pageable) {
 		return videoRepository.findVideosByDescription(description, pageable);
-	}
-
-	public void saveViewHistory(AuthMember authMember, Video video) {
-		final Member loginMember = memberReadService.findMember(authMember.email());
-		viewHistoryService.saveViewHistory(loginMember, video);
 	}
 
 	public List<ViewHistoryListResponse> findAllViewHistory(AuthMember authMember) {

--- a/src/main/java/com/vidcentral/api/application/video/VideoReadService.java
+++ b/src/main/java/com/vidcentral/api/application/video/VideoReadService.java
@@ -43,18 +43,26 @@ public class VideoReadService {
 		return videoRepository.findAll();
 	}
 
+	public List<Video> findAllVideosByTitle(String title) {
+		return videoRepository.findVideosByTitle(title);
+	}
+
+	public List<Video> findAllVideosByDescription(String description) {
+		return videoRepository.findVideosByDescription(description);
+	}
+
 	public void saveViewHistory(AuthMember authMember, Video video) {
 		final Member loginMember = memberReadService.findMember(authMember.email());
 		viewHistoryService.saveViewHistory(loginMember, video);
 	}
 
-	public List<ViewHistoryListResponse> searchAllViewHistory(AuthMember authMember) {
+	public List<ViewHistoryListResponse> findAllViewHistory(AuthMember authMember) {
 		return Optional.ofNullable(authMember)
 			.map(viewHistoryService::searchAllViewHistory)
 			.orElseThrow(() -> new BadRequestException(FAILED_INVALID_REQUEST_ERROR));
 	}
 
-	public List<VideoListResponse> searchAllRecommendationVideos(Member member) {
+	public List<VideoListResponse> findAllRecommendationVideos(Member member) {
 		final Set<VideoTag> likedVideoTags = recommendationService.extractLikedVideoTags(member);
 		final Set<String> likedVideoTitles = recommendationService.extractLikedVideoTitle(member);
 		final Set<VideoTag> viewHistoryVideoTags = recommendationService.extractViewHistoryVideoTags(member);

--- a/src/main/java/com/vidcentral/api/application/video/VideoReadService.java
+++ b/src/main/java/com/vidcentral/api/application/video/VideoReadService.java
@@ -2,6 +2,7 @@ package com.vidcentral.api.application.video;
 
 import static com.vidcentral.global.error.model.ErrorMessage.*;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -45,12 +46,23 @@ public class VideoReadService {
 		return videoRepository.findAll(pageable);
 	}
 
-	public List<Video> findAllVideosByTitle(String title) {
-		return videoRepository.findVideosByTitle(title);
+	public Set<Video> findAllVideosByKeyword(String keyword, Pageable pageable) {
+		final Page<Video> videosFoundByTitle = findAllVideosByTitle(keyword, pageable);
+		final Page<Video> videosFoundByDescription = findAllVideosByDescription(keyword, pageable);
+
+		final Set<Video> distinctVideos = new HashSet<>();
+		distinctVideos.addAll(videosFoundByTitle.getContent());
+		distinctVideos.addAll(videosFoundByDescription.getContent());
+
+		return distinctVideos;
 	}
 
-	public List<Video> findAllVideosByDescription(String description) {
-		return videoRepository.findVideosByDescription(description);
+	private Page<Video> findAllVideosByTitle(String title, Pageable pageable) {
+		return videoRepository.findVideosByTitle(title, pageable);
+	}
+
+	private Page<Video> findAllVideosByDescription(String description, Pageable pageable) {
+		return videoRepository.findVideosByDescription(description, pageable);
 	}
 
 	public void saveViewHistory(AuthMember authMember, Video video) {

--- a/src/main/java/com/vidcentral/api/application/video/VideoService.java
+++ b/src/main/java/com/vidcentral/api/application/video/VideoService.java
@@ -56,16 +56,7 @@ public class VideoService {
 	}
 
 	public PageResponse<VideoListResponse> searchAllVideosByKeyword(SearchVideoRequest searchVideoRequest, int page, int size) {
-		final Set<Video> distinctVideos = videoReadService
-			.findAllVideosByKeyword(searchVideoRequest.keyword(), PageRequest.of(page, size));
-
-		final List<VideoListResponse> videoListResponses = distinctVideos.stream()
-			.map(VideoMapper::toVideoListResponse)
-			.toList();
-
-		final Page<VideoListResponse> videoListResponsePage = PageMapper
-			.toPageImpl(videoListResponses, PageRequest.of(page, size), distinctVideos.size());
-		return PageMapper.toPageResponse(videoListResponsePage);
+		return videoReadService.findAllVideosByKeyword(searchVideoRequest, PageRequest.of(page, size));
 	}
 
 	public VideoDetailResponse searchVideo(AuthMember authMember, Long videoId) {
@@ -77,8 +68,8 @@ public class VideoService {
 		return VideoMapper.toVideoDetailsResponse(video);
 	}
 
-	public List<ViewHistoryListResponse> searchAllViewHistory(AuthMember authMember) {
-		return videoReadService.findAllViewHistory(authMember);
+	public PageResponse<ViewHistoryListResponse> searchAllViewHistory(AuthMember authMember, int page, int size) {
+		return videoReadService.findAllViewHistory(authMember, PageRequest.of(page, size));
 	}
 
 	public List<VideoListResponse> searchAllRecommendationVideos(AuthMember authMember) {

--- a/src/main/java/com/vidcentral/api/application/video/VideoService.java
+++ b/src/main/java/com/vidcentral/api/application/video/VideoService.java
@@ -2,9 +2,6 @@ package com.vidcentral.api.application.video;
 
 import static com.vidcentral.api.domain.video.entity.VideoProperties.*;
 
-import java.util.List;
-import java.util.Set;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -55,7 +52,9 @@ public class VideoService {
 		return PageMapper.toPageResponse(videoPage.map(VideoMapper::toVideoListResponse));
 	}
 
-	public PageResponse<VideoListResponse> searchAllVideosByKeyword(SearchVideoRequest searchVideoRequest, int page, int size) {
+	public PageResponse<VideoListResponse> searchAllVideosByKeyword(SearchVideoRequest searchVideoRequest, int page,
+		int size) {
+
 		return videoReadService.findAllVideosByKeyword(searchVideoRequest, PageRequest.of(page, size));
 	}
 
@@ -72,13 +71,15 @@ public class VideoService {
 		return videoReadService.findAllViewHistory(authMember, PageRequest.of(page, size));
 	}
 
-	public List<VideoListResponse> searchAllRecommendationVideos(AuthMember authMember) {
+	public PageResponse<VideoListResponse> searchAllRecommendationVideos(AuthMember authMember, int page, int size) {
 		final Member loginMember = memberReadService.findMember(authMember.email());
-		return videoReadService.findAllRecommendationVideos(loginMember);
+		return videoReadService.findAllRecommendationVideos(loginMember, PageRequest.of(page, size));
 	}
 
 	@Transactional
-	public void updateVideo(AuthMember authMember, Long videoId, UpdateVideoRequest updateVideoRequest, MultipartFile videoURL) {
+	public void updateVideo(AuthMember authMember, Long videoId, UpdateVideoRequest updateVideoRequest,
+		MultipartFile videoURL) {
+
 		final Member loginMember = memberReadService.findMember(authMember.email());
 		final Video video = videoReadService.findVideo(videoId);
 

--- a/src/main/java/com/vidcentral/api/application/video/VideoService.java
+++ b/src/main/java/com/vidcentral/api/application/video/VideoService.java
@@ -6,6 +6,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -18,6 +20,7 @@ import com.vidcentral.api.domain.video.entity.Video;
 import com.vidcentral.api.dto.request.video.SearchVideoRequest;
 import com.vidcentral.api.dto.request.video.UpdateVideoRequest;
 import com.vidcentral.api.dto.request.video.UploadVideoRequest;
+import com.vidcentral.api.dto.response.page.PageResponse;
 import com.vidcentral.api.dto.response.video.VideoDetailResponse;
 import com.vidcentral.api.dto.response.video.VideoListResponse;
 import com.vidcentral.api.dto.response.viewHistory.ViewHistoryListResponse;
@@ -45,12 +48,9 @@ public class VideoService {
 		return videoWriteService.saveVideo(video);
 	}
 
-	public List<VideoListResponse> searchAllVideos() {
-		List<Video> videoList = videoReadService.findAllVideos();
-
-		return videoList.stream()
-			.map(VideoMapper::toVideoListResponse)
-			.toList();
+	public PageResponse<VideoListResponse> searchAllVideos(int page, int size) {
+		Page<Video> videoPage = videoReadService.findAllVideos(PageRequest.of(page, size));
+		return VideoMapper.toPageResponse(videoPage);
 	}
 
 	public List<VideoListResponse> searchAllVideosByKeyword(SearchVideoRequest searchVideoRequest) {

--- a/src/main/java/com/vidcentral/api/application/viewHistory/ViewHistoryService.java
+++ b/src/main/java/com/vidcentral/api/application/viewHistory/ViewHistoryService.java
@@ -2,14 +2,18 @@ package com.vidcentral.api.application.viewHistory;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import com.vidcentral.api.application.member.MemberReadService;
+import com.vidcentral.api.application.page.PageMapper;
 import com.vidcentral.api.domain.auth.entity.AuthMember;
 import com.vidcentral.api.domain.member.entity.Member;
 import com.vidcentral.api.domain.video.entity.Video;
 import com.vidcentral.api.domain.viewHistory.entity.ViewHistory;
 import com.vidcentral.api.domain.viewHistory.repository.ViewHistoryRepository;
+import com.vidcentral.api.dto.response.page.PageResponse;
 import com.vidcentral.api.dto.response.viewHistory.ViewHistoryListResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -26,12 +30,16 @@ public class ViewHistoryService {
 		viewHistoryRepository.save(viewHistory);
 	}
 
-	public List<ViewHistoryListResponse> searchAllViewHistory(AuthMember authMember) {
+	public PageResponse<ViewHistoryListResponse> searchAllViewHistory(AuthMember authMember, Pageable pageable) {
 		final Member loginMember = memberReadService.findMember(authMember.email());
-		final List<ViewHistory> viewHistoryList = viewHistoryRepository.findViewHistoriesByMember(loginMember);
+		final Page<ViewHistory> viewHistoryList = viewHistoryRepository
+			.findViewHistoriesByMember(loginMember, pageable);
 
-		return viewHistoryList.stream()
+		final List<ViewHistoryListResponse> viewHistoryListResponses = viewHistoryList.getContent().stream()
 			.map(ViewHistoryMapper::toViewHistoryListResponse)
 			.toList();
+
+		return PageMapper.toPageResponse(
+			PageMapper.toPageImpl(viewHistoryListResponses, pageable, viewHistoryList.getTotalElements()));
 	}
 }

--- a/src/main/java/com/vidcentral/api/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/vidcentral/api/domain/comment/repository/CommentRepository.java
@@ -1,8 +1,9 @@
 package com.vidcentral.api.domain.comment.repository;
 
-import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -14,5 +15,5 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
 	Optional<Comment> findCommentByVideo(Video video);
 
-	List<Comment> findCommentsByVideo(Video video);
+	Page<Comment> findCommentsByVideo(Video video, Pageable pageable);
 }

--- a/src/main/java/com/vidcentral/api/domain/video/repository/VideoRepository.java
+++ b/src/main/java/com/vidcentral/api/domain/video/repository/VideoRepository.java
@@ -1,7 +1,7 @@
 package com.vidcentral.api.domain.video.repository;
 
-import java.util.List;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,7 +10,7 @@ import com.vidcentral.api.domain.video.entity.Video;
 @Repository
 public interface VideoRepository extends JpaRepository<Video, Long> {
 
-	List<Video> findVideosByTitle(String title);
+	Page<Video> findVideosByTitle(String title, Pageable pageable);
 
-	List<Video> findVideosByDescription(String description);
+	Page<Video> findVideosByDescription(String description, Pageable pageable);
 }

--- a/src/main/java/com/vidcentral/api/domain/video/repository/VideoRepository.java
+++ b/src/main/java/com/vidcentral/api/domain/video/repository/VideoRepository.java
@@ -1,5 +1,7 @@
 package com.vidcentral.api.domain.video.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,4 +9,8 @@ import com.vidcentral.api.domain.video.entity.Video;
 
 @Repository
 public interface VideoRepository extends JpaRepository<Video, Long> {
+
+	List<Video> findVideosByTitle(String title);
+
+	List<Video> findVideosByDescription(String description);
 }

--- a/src/main/java/com/vidcentral/api/domain/viewHistory/repository/ViewHistoryRepository.java
+++ b/src/main/java/com/vidcentral/api/domain/viewHistory/repository/ViewHistoryRepository.java
@@ -2,6 +2,8 @@ package com.vidcentral.api.domain.viewHistory.repository;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,7 +13,7 @@ import com.vidcentral.api.domain.viewHistory.entity.ViewHistory;
 @Repository
 public interface ViewHistoryRepository extends JpaRepository<ViewHistory, Long> {
 
-	List<ViewHistory> findViewHistoriesByMember(Member member);
+	Page<ViewHistory> findViewHistoriesByMember(Member member, Pageable pageable);
 
 	List<ViewHistory> findAllByMember(Member member);
 }

--- a/src/main/java/com/vidcentral/api/dto/request/auth/LoginRequest.java
+++ b/src/main/java/com/vidcentral/api/dto/request/auth/LoginRequest.java
@@ -1,10 +1,18 @@
 package com.vidcentral.api.dto.request.auth;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "사용자 로그인 요청")
 public record LoginRequest(
+	@NotBlank(message = "이메일은 필수 입력 항목입니다.")
+	@Schema(description = "사용자 이메일", example = "memberEmail@example.com")
 	String email,
+
+	@NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
+	@Schema(description = "사용자 비밀번호", example = "memberPassword123")
 	String password
 ) {
 }

--- a/src/main/java/com/vidcentral/api/dto/request/comment/UpdateCommentRequest.java
+++ b/src/main/java/com/vidcentral/api/dto/request/comment/UpdateCommentRequest.java
@@ -1,9 +1,14 @@
 package com.vidcentral.api.dto.request.comment;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 
+@Builder
+@Schema(description = "댓글 수정 요청")
 public record UpdateCommentRequest(
 	@NotBlank(message = "댓글 내용은 필수 입력 항목입니다.")
+	@Schema(description = "댓글 내용", example = "commentContent")
 	String content
 ) {
 }

--- a/src/main/java/com/vidcentral/api/dto/request/comment/UploadCommentRequest.java
+++ b/src/main/java/com/vidcentral/api/dto/request/comment/UploadCommentRequest.java
@@ -1,11 +1,14 @@
 package com.vidcentral.api.dto.request.comment;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "댓글 업로드 요청")
 public record UploadCommentRequest(
 	@NotBlank(message = "댓글 내용은 필수 입력 항목입니다.")
+	@Schema(description = "댓글 내용", example = "commentContent")
 	String content
 ) {
 }

--- a/src/main/java/com/vidcentral/api/dto/request/member/SignUpRequest.java
+++ b/src/main/java/com/vidcentral/api/dto/request/member/SignUpRequest.java
@@ -1,5 +1,6 @@
 package com.vidcentral.api.dto.request.member;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -7,21 +8,25 @@ import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "사용자 회원가입 요청")
 public record SignUpRequest(
 	@Email(message = "유효한 이메일 형식을 입력해주세요.")
+	@Schema(description = "사용자 이메일", example = "memberEmail@example.com")
 	String email,
 
 	@NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
 	@Size(min = 5, max = 20, message = "비밀번호는 5자 이상 20자 이하로 설정해야 합니다.")
-	@Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{5,20}$",
-		message = "비밀번호는 영문자와 숫자를 모두 포함해야 합니다.")
+	@Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{5,20}$", message = "비밀번호는 영문자와 숫자를 모두 포함해야 합니다.")
+	@Schema(description = "사용자 비밀번호", example = "memberPassword123")
 	String password,
 
 	@NotBlank(message = "비밀번호 확인은 필수 입력 항목입니다.")
+	@Schema(description = "사용자 비밀번호 확인", example = "memberPassword123")
 	String checkPassword,
 
 	@NotBlank(message = "닉네임은 필수 입력 항목입니다.")
 	@Size(min = 3, max = 20, message = "닉네임은 3자 이상 20자 이하로 설정해야 합니다.")
+	@Schema(description = "사용자 닉네임", example = "memberNickname")
 	String nickname
 ) {
 }

--- a/src/main/java/com/vidcentral/api/dto/request/member/UpdateMemberRequest.java
+++ b/src/main/java/com/vidcentral/api/dto/request/member/UpdateMemberRequest.java
@@ -1,11 +1,13 @@
 package com.vidcentral.api.dto.request.member;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
 @Builder
-public record UpdateRequest(
+@Schema(description = "사용자 정보 수정 요청")
+public record UpdateMemberRequest(
 	@NotBlank(message = "닉네임은 필수 입력 항목입니다.")
 	@Size(min = 3, max = 20, message = "닉네임은 3자 이상 20자 이하로 설정해야 합니다.")
 	String nickname,

--- a/src/main/java/com/vidcentral/api/dto/request/video/SearchVideoRequest.java
+++ b/src/main/java/com/vidcentral/api/dto/request/video/SearchVideoRequest.java
@@ -1,11 +1,14 @@
 package com.vidcentral.api.dto.request.video;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "비디오 검색 키워드 요청")
 public record SearchVideoRequest(
 	@NotBlank(message = "검색 키워드는 필수 입력 항목입니다.")
+	@Schema(description = "검색 키워드", example = "keyword")
 	String keyword
 ) {
 }

--- a/src/main/java/com/vidcentral/api/dto/request/video/SearchVideoRequest.java
+++ b/src/main/java/com/vidcentral/api/dto/request/video/SearchVideoRequest.java
@@ -1,0 +1,11 @@
+package com.vidcentral.api.dto.request.video;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+@Builder
+public record SearchVideoRequest(
+	@NotBlank(message = "검색 키워드는 필수 입력 항목입니다.")
+	String keyword
+) {
+}

--- a/src/main/java/com/vidcentral/api/dto/request/video/UpdateVideoRequest.java
+++ b/src/main/java/com/vidcentral/api/dto/request/video/UpdateVideoRequest.java
@@ -4,17 +4,22 @@ import java.util.Set;
 
 import com.vidcentral.api.domain.video.entity.VideoTag;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "비디오 정보 수정 요청")
 public record UpdateVideoRequest(
 	@NotBlank(message = "비디오 제목은 필수 입력 항목입니다.")
+	@Schema(description = "비디오 제목", example = "videoTitle")
 	String title,
 
 	@NotBlank(message = "비디오 설명은 필수 입력 항목입니다.")
+	@Schema(description = "비디오 설명", example = "videoDescription")
 	String description,
 
+	@Schema(description = "비디오 태그", example = "videoTags")
 	Set<VideoTag> videoTags
 ) {
 }

--- a/src/main/java/com/vidcentral/api/dto/request/video/UploadVideoRequest.java
+++ b/src/main/java/com/vidcentral/api/dto/request/video/UploadVideoRequest.java
@@ -4,18 +4,23 @@ import java.util.Set;
 
 import com.vidcentral.api.domain.video.entity.VideoTag;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "비디오 업로드 요청")
 public record UploadVideoRequest(
 	@NotBlank(message = "비디오 제목은 필수 입력 항목입니다.")
+	@Schema(description = "비디오 제목", example = "videoTitle")
 	String title,
 
 	@NotBlank(message = "비디오 설명은 필수 입력 항목입니다.")
+	@Schema(description = "비디오 설명", example = "videoDescription")
 	String description,
 
 	@NotBlank(message = "비디오 태그는 필수 입력 항목입니다.")
+	@Schema(description = "비디오 태그", example = "videoTags")
 	Set<VideoTag> videoTags
 ) {
 }

--- a/src/main/java/com/vidcentral/api/dto/response/auth/LoginResponse.java
+++ b/src/main/java/com/vidcentral/api/dto/response/auth/LoginResponse.java
@@ -1,10 +1,15 @@
 package com.vidcentral.api.dto.response.auth;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "사용자 로그인 응답")
 public record LoginResponse(
+	@Schema(description = "액세스 토큰", example = "eyJhbGciOiJIUzI1NiIsInR...")
 	String accessToken,
+
+	@Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiIsInR...")
 	String refreshToken
 ) {
 }

--- a/src/main/java/com/vidcentral/api/dto/response/auth/TokenSaveResponse.java
+++ b/src/main/java/com/vidcentral/api/dto/response/auth/TokenSaveResponse.java
@@ -1,9 +1,12 @@
 package com.vidcentral.api.dto.response.auth;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "토큰 저장 응답")
 public record TokenSaveResponse(
+	@Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiIsInR...")
 	String refreshToken
 ) {
 }

--- a/src/main/java/com/vidcentral/api/dto/response/comment/CommentListResponse.java
+++ b/src/main/java/com/vidcentral/api/dto/response/comment/CommentListResponse.java
@@ -1,10 +1,15 @@
 package com.vidcentral.api.dto.response.comment;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "댓글 목록 응답")
 public record CommentListResponse(
+	@Schema(description = "사용자 닉네임", example = "memberNickname")
 	String nickname,
+
+	@Schema(description = "댓글 내용", example = "commentContent")
 	String content
 ) {
 }

--- a/src/main/java/com/vidcentral/api/dto/response/comment/CommentListResponse.java
+++ b/src/main/java/com/vidcentral/api/dto/response/comment/CommentListResponse.java
@@ -3,7 +3,7 @@ package com.vidcentral.api.dto.response.comment;
 import lombok.Builder;
 
 @Builder
-public record CommentResponse(
+public record CommentListResponse(
 	String nickname,
 	String content
 ) {

--- a/src/main/java/com/vidcentral/api/dto/response/member/MemberInfoResponse.java
+++ b/src/main/java/com/vidcentral/api/dto/response/member/MemberInfoResponse.java
@@ -1,10 +1,15 @@
 package com.vidcentral.api.dto.response.member;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "사용자 정보 응답")
 public record MemberInfoResponse(
+	@Schema(description = "사용자 닉네임", example = "memberNickname")
 	String nickname,
+
+	@Schema(description = "사용자 소개글", example = "memberIntroduce")
 	String introduce
 ) {
 }

--- a/src/main/java/com/vidcentral/api/dto/response/page/PageResponse.java
+++ b/src/main/java/com/vidcentral/api/dto/response/page/PageResponse.java
@@ -2,14 +2,25 @@ package com.vidcentral.api.dto.response.page;
 
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "페이지네이션 응답")
 public record PageResponse<T>(
+	@Schema(description = "현재 페이지의 콘텐츠 목록")
 	List<T> content,
+
+	@Schema(description = "현재 페이지 인덱스 (0부터 시작)", example = "0")
 	int pageIndex,
+
+	@Schema(description = "총 페이지 수", example = "10")
 	int totalPages,
+
+	@Schema(description = "총 요소 수", example = "100")
 	long totalElements,
+
+	@Schema(description = "마지막 페이지 여부", example = "true")
 	boolean isLast
 ) {
 }

--- a/src/main/java/com/vidcentral/api/dto/response/page/PageResponse.java
+++ b/src/main/java/com/vidcentral/api/dto/response/page/PageResponse.java
@@ -1,0 +1,15 @@
+package com.vidcentral.api.dto.response.page;
+
+import java.util.List;
+
+import lombok.Builder;
+
+@Builder
+public record PageResponse<T>(
+	List<T> content,
+	int pageIndex,
+	int totalPages,
+	long totalElements,
+	boolean isLast
+) {
+}

--- a/src/main/java/com/vidcentral/api/dto/response/video/VideoDetailResponse.java
+++ b/src/main/java/com/vidcentral/api/dto/response/video/VideoDetailResponse.java
@@ -1,13 +1,24 @@
 package com.vidcentral.api.dto.response.video;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "비디오 상세 정보 응답")
 public record VideoDetailResponse(
+	@Schema(description = "비디오 업로더 사용자 닉네임", example = "uploaderMemberNickname")
 	String nickname,
+
+	@Schema(description = "비디오 제목", example = "videoTitle")
 	String title,
+
+	@Schema(description = "비디오 설명", example = "videoDescription")
 	String description,
+
+	@Schema(description = "비디오 URL", example = "https://example.com/video1")
 	String videoURL,
+
+	@Schema(description = "비디오 조회수", example = "1500")
 	Long views
 ) {
 }

--- a/src/main/java/com/vidcentral/api/dto/response/video/VideoListResponse.java
+++ b/src/main/java/com/vidcentral/api/dto/response/video/VideoListResponse.java
@@ -1,12 +1,21 @@
 package com.vidcentral.api.dto.response.video;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "비디오 목록 응답")
 public record VideoListResponse(
+	@Schema(description = "비디오 업로더 사용자 닉네임", example = "uploaderMemberNickname")
 	String nickname,
+
+	@Schema(description = "비디오 제목", example = "videoTitle")
 	String title,
+
+	@Schema(description = "비디오 URL", example = "https://example.com/video1")
 	String videoURL,
+
+	@Schema(description = "비디오 조회수", example = "1500")
 	Long views
 ) {
 }

--- a/src/main/java/com/vidcentral/api/dto/response/viewHistory/ViewHistoryListResponse.java
+++ b/src/main/java/com/vidcentral/api/dto/response/viewHistory/ViewHistoryListResponse.java
@@ -2,14 +2,25 @@ package com.vidcentral.api.dto.response.viewHistory;
 
 import java.time.LocalDateTime;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "비디오 시청 기록 목록 응답")
 public record ViewHistoryListResponse(
+	@Schema(description = "비디오 제목", example = "videoTitle")
 	String title,
+
+	@Schema(description = "비디오 설명", example = "videoDescription")
 	String description,
+
+	@Schema(description = "비디오 URL", example = "https://example.com/video1")
 	String videoURL,
+
+	@Schema(description = "비디오 조회수", example = "1500")
 	Long views,
+
+	@Schema(description = "비디오 시청 시간", example = "2023-02-03T10:15:30")
 	LocalDateTime watchedAt
 ) {
 }

--- a/src/main/java/com/vidcentral/api/presentation/comment/CommentController.java
+++ b/src/main/java/com/vidcentral/api/presentation/comment/CommentController.java
@@ -1,7 +1,5 @@
 package com.vidcentral.api.presentation.comment;
 
-import java.util.List;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -10,6 +8,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,6 +18,7 @@ import com.vidcentral.api.domain.auth.entity.AuthMember;
 import com.vidcentral.api.dto.request.comment.UpdateCommentRequest;
 import com.vidcentral.api.dto.request.comment.UploadCommentRequest;
 import com.vidcentral.api.dto.response.comment.CommentResponse;
+import com.vidcentral.api.dto.response.page.PageResponse;
 import com.vidcentral.global.auth.annotation.AuthenticationMember;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -66,8 +66,12 @@ public class CommentController {
 		@ApiResponse(responseCode = "404", description = "실패 - 해당 회원을 찾을 수 없습니다."),
 		@ApiResponse(responseCode = "500", description = "실패 - 서버 오류, 요청 처리 중 문제가 발생했습니다.")
 	})
-	public ResponseEntity<List<CommentResponse>> searchAllComments(@PathVariable Long videoId) {
-		return ResponseEntity.ok().body(commentService.searchAllComments(videoId));
+	public ResponseEntity<PageResponse<CommentResponse>> searchAllComments(
+		@PathVariable Long videoId,
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "10") int size) {
+
+		return ResponseEntity.ok().body(commentService.searchAllComments(videoId, page, size));
 	}
 
 	@PutMapping("/update/{videoId}")

--- a/src/main/java/com/vidcentral/api/presentation/comment/CommentController.java
+++ b/src/main/java/com/vidcentral/api/presentation/comment/CommentController.java
@@ -17,7 +17,7 @@ import com.vidcentral.api.application.comment.CommentService;
 import com.vidcentral.api.domain.auth.entity.AuthMember;
 import com.vidcentral.api.dto.request.comment.UpdateCommentRequest;
 import com.vidcentral.api.dto.request.comment.UploadCommentRequest;
-import com.vidcentral.api.dto.response.comment.CommentResponse;
+import com.vidcentral.api.dto.response.comment.CommentListResponse;
 import com.vidcentral.api.dto.response.page.PageResponse;
 import com.vidcentral.global.auth.annotation.AuthenticationMember;
 
@@ -66,7 +66,7 @@ public class CommentController {
 		@ApiResponse(responseCode = "404", description = "실패 - 해당 회원을 찾을 수 없습니다."),
 		@ApiResponse(responseCode = "500", description = "실패 - 서버 오류, 요청 처리 중 문제가 발생했습니다.")
 	})
-	public ResponseEntity<PageResponse<CommentResponse>> searchAllComments(
+	public ResponseEntity<PageResponse<CommentListResponse>> searchAllComments(
 		@PathVariable Long videoId,
 		@RequestParam(defaultValue = "0") int page,
 		@RequestParam(defaultValue = "10") int size) {

--- a/src/main/java/com/vidcentral/api/presentation/member/MemberController.java
+++ b/src/main/java/com/vidcentral/api/presentation/member/MemberController.java
@@ -17,7 +17,7 @@ import com.vidcentral.api.application.member.MemberService;
 import com.vidcentral.api.domain.auth.entity.AuthMember;
 import com.vidcentral.api.dto.request.auth.LoginRequest;
 import com.vidcentral.api.dto.request.member.SignUpRequest;
-import com.vidcentral.api.dto.request.member.UpdateRequest;
+import com.vidcentral.api.dto.request.member.UpdateMemberRequest;
 import com.vidcentral.api.dto.response.auth.LoginResponse;
 import com.vidcentral.api.dto.response.member.MemberInfoResponse;
 import com.vidcentral.global.auth.annotation.AuthenticationMember;
@@ -105,10 +105,10 @@ public class MemberController {
 	})
 	public ResponseEntity<String> updateMemberInfo(
 		@AuthenticationMember AuthMember authMember,
-		@Valid @RequestPart(required = false) UpdateRequest updateRequest,
+		@Valid @RequestPart(required = false) UpdateMemberRequest updateMemberRequest,
 		@RequestPart(name = "profileImageURL") MultipartFile newProfileImageURL) {
 
-		memberService.updateMemberInfo(authMember, updateRequest, newProfileImageURL);
+		memberService.updateMemberInfo(authMember, updateMemberRequest, newProfileImageURL);
 		return ResponseEntity.ok().body("성공적으로 회원 정보가 업데이트되었습니다.");
 	}
 }

--- a/src/main/java/com/vidcentral/api/presentation/video/VideoController.java
+++ b/src/main/java/com/vidcentral/api/presentation/video/VideoController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,6 +23,7 @@ import com.vidcentral.api.domain.video.entity.Video;
 import com.vidcentral.api.dto.request.video.SearchVideoRequest;
 import com.vidcentral.api.dto.request.video.UpdateVideoRequest;
 import com.vidcentral.api.dto.request.video.UploadVideoRequest;
+import com.vidcentral.api.dto.response.page.PageResponse;
 import com.vidcentral.api.dto.response.video.VideoDetailResponse;
 import com.vidcentral.api.dto.response.video.VideoListResponse;
 import com.vidcentral.api.dto.response.viewHistory.ViewHistoryListResponse;
@@ -73,8 +75,11 @@ public class VideoController {
 		@ApiResponse(responseCode = "404", description = "실패 - 해당 비디오를 찾을 수 없습니다."),
 		@ApiResponse(responseCode = "500", description = "실패 - 서버 오류, 요청 처리 중 문제가 발생했습니다.")
 	})
-	public ResponseEntity<List<VideoListResponse>> searchAllVideos() {
-		return ResponseEntity.ok().body(videoService.searchAllVideos());
+	public ResponseEntity<PageResponse<VideoListResponse>> searchAllVideos(
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "10") int size) {
+
+		return ResponseEntity.ok().body(videoService.searchAllVideos(page, size));
 	}
 
 	@GetMapping("/keyword")

--- a/src/main/java/com/vidcentral/api/presentation/video/VideoController.java
+++ b/src/main/java/com/vidcentral/api/presentation/video/VideoController.java
@@ -19,6 +19,7 @@ import org.springframework.web.multipart.MultipartFile;
 import com.vidcentral.api.application.video.VideoService;
 import com.vidcentral.api.domain.auth.entity.AuthMember;
 import com.vidcentral.api.domain.video.entity.Video;
+import com.vidcentral.api.dto.request.video.SearchVideoRequest;
 import com.vidcentral.api.dto.request.video.UpdateVideoRequest;
 import com.vidcentral.api.dto.request.video.UploadVideoRequest;
 import com.vidcentral.api.dto.response.video.VideoDetailResponse;
@@ -64,35 +65,34 @@ public class VideoController {
 	@GetMapping
 	@ResponseStatus(HttpStatus.OK)
 	@Operation(
-		summary = "모든 비디오 조회 API",
-		description = "모든 비디오 제목, 설명, 파일을 조회합니다."
+		summary = "비디오 목록 조회 API",
+		description = "비디오 제목, 설명, 파일 목록을 조회합니다."
 	)
 	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "성공 - 모든 비디오 조회, 모든 비디오 정보를 조회했습니다."),
-		@ApiResponse(responseCode = "404", description = "실패 - 해당 회원을 찾을 수 없습니다."),
-		@ApiResponse(responseCode = "409", description = "실패 - 유효하지 않은 비디오 파일입니다."),
+		@ApiResponse(responseCode = "200", description = "성공 - 비디오 목록 조회, 모든 비디오 정보를 조회했습니다."),
+		@ApiResponse(responseCode = "404", description = "실패 - 해당 비디오를 찾을 수 없습니다."),
 		@ApiResponse(responseCode = "500", description = "실패 - 서버 오류, 요청 처리 중 문제가 발생했습니다.")
 	})
 	public ResponseEntity<List<VideoListResponse>> searchAllVideos() {
 		return ResponseEntity.ok().body(videoService.searchAllVideos());
 	}
 
-	@GetMapping("/view-history")
+	@GetMapping("/keyword")
 	@ResponseStatus(HttpStatus.OK)
 	@Operation(
-		summary = "모든 비디오 시청 기록 조회 API",
-		description = "모든 비디오 제목, 설명, 파일, 조회수, 시청 시간을 조회합니다."
+		summary = "키워드로 비디오 목록 조회 API",
+		description = "사용자가 입력한 키워드를 기반으로 제목과 설명에 일치하는 비디오 목록을 조회합니다."
 	)
 	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "성공 - 모든 비디오 시청 기록 조회, 모든 비디오 시청 기록을 조회했습니다."),
-		@ApiResponse(responseCode = "404", description = "실패 - 해당 회원을 찾을 수 없습니다."),
-		@ApiResponse(responseCode = "409", description = "실패 - 유효하지 않은 비디오 파일입니다."),
+		@ApiResponse(responseCode = "200", description = "성공 - 키워드로 비디오 목록 조회, 모든 비디오 정보를 조회했습니다."),
+		@ApiResponse(responseCode = "400", description = "실패 - 잘못된 요청, 검색어가 유효하지 않습니다."),
+		@ApiResponse(responseCode = "404", description = "실패 - 해당 비디오를 찾을 수 없습니다."),
 		@ApiResponse(responseCode = "500", description = "실패 - 서버 오류, 요청 처리 중 문제가 발생했습니다.")
 	})
-	public ResponseEntity<List<ViewHistoryListResponse>> searchAllViewHistory(
-		@AuthenticationMember AuthMember authMember) {
+	public ResponseEntity<List<VideoListResponse>> searchAllVideosByKeyword(
+		@Valid @RequestPart(required = false) SearchVideoRequest searchVideoRequest) {
 
-		return ResponseEntity.ok().body(videoService.searchAllViewHistory(authMember));
+		return ResponseEntity.ok().body(videoService.searchAllVideosByKeyword(searchVideoRequest));
 	}
 
 	@GetMapping("/{videoId}")
@@ -102,7 +102,7 @@ public class VideoController {
 		description = "비디오 제목, 설명, 파일을 조회합니다."
 	)
 	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "성공 - 비디오 조회, 비디오 정보를 조회했습니다.."),
+		@ApiResponse(responseCode = "200", description = "성공 - 비디오 조회, 비디오 정보를 조회했습니다."),
 		@ApiResponse(responseCode = "404", description = "실패 - 해당 회원을 찾을 수 없습니다."),
 		@ApiResponse(responseCode = "409", description = "실패 - 유효하지 않은 비디오 파일입니다."),
 		@ApiResponse(responseCode = "500", description = "실패 - 서버 오류, 요청 처리 중 문제가 발생했습니다.")
@@ -114,16 +114,32 @@ public class VideoController {
 		return ResponseEntity.ok().body(videoService.searchVideo(authMember, videoId));
 	}
 
+	@GetMapping("/view-history")
+	@ResponseStatus(HttpStatus.OK)
+	@Operation(
+		summary = "비디오 시청 기록 목록 조회 API",
+		description = "비디오 제목, 설명, 파일, 조회수, 시청 시간 목록을 조회합니다."
+	)
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "성공 - 비디오 시청 기록 목록 조회, 모든 비디오 시청 기록을 조회했습니다."),
+		@ApiResponse(responseCode = "404", description = "실패 - 해당 회원을 찾을 수 없습니다."),
+		@ApiResponse(responseCode = "500", description = "실패 - 서버 오류, 요청 처리 중 문제가 발생했습니다.")
+	})
+	public ResponseEntity<List<ViewHistoryListResponse>> searchAllViewHistory(
+		@AuthenticationMember AuthMember authMember) {
+
+		return ResponseEntity.ok().body(videoService.searchAllViewHistory(authMember));
+	}
+
 	@GetMapping("/recommendation")
 	@ResponseStatus(HttpStatus.OK)
 	@Operation(
-		summary = "모든 추천 비디오 조회 API",
-		description = "모든 추천 비디오 영상을 조회합니다."
+		summary = "추천 비디오 목록 조회 API",
+		description = "추천 비디오 영상 목록을 조회합니다."
 	)
 	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "성공 - 모든 추천 비디오 조회, 비디오 정보를 조회했습니다.."),
+		@ApiResponse(responseCode = "200", description = "성공 - 추천 비디오 목록 조회, 모든 추천 비디오 정보를 조회했습니다."),
 		@ApiResponse(responseCode = "404", description = "실패 - 해당 회원을 찾을 수 없습니다."),
-		@ApiResponse(responseCode = "409", description = "실패 - 유효하지 않은 비디오 파일입니다."),
 		@ApiResponse(responseCode = "500", description = "실패 - 서버 오류, 요청 처리 중 문제가 발생했습니다.")
 	})
 	public ResponseEntity<List<VideoListResponse>> searchAllRecommendationVideos(
@@ -141,8 +157,7 @@ public class VideoController {
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "성공 - 비디오 수정, 비디오 정보가 업데이트되었습니다."),
 		@ApiResponse(responseCode = "400", description = "실패 - 잘못된 요청, 필수 입력값이 누락되었거나 형식이 올바르지 않습니다."),
-		@ApiResponse(responseCode = "404", description = "실패 - 해당 회원을 찾을 수 없습니다."),
-		@ApiResponse(responseCode = "409", description = "실패 - 유효하지 않은 비디오 파일입니다."),
+		@ApiResponse(responseCode = "404", description = "실패 - 해당 회원 또는 비디오를 찾을 수 없습니다."),
 		@ApiResponse(responseCode = "500", description = "실패 - 서버 오류, 요청 처리 중 문제가 발생했습니다.")
 	})
 	public ResponseEntity<String> updateVideo(
@@ -164,8 +179,7 @@ public class VideoController {
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "성공 - 비디오 삭제, 비디오 정보가 삭제되었습니다."),
 		@ApiResponse(responseCode = "400", description = "실패 - 잘못된 요청, 필수 입력값이 누락되었거나 형식이 올바르지 않습니다."),
-		@ApiResponse(responseCode = "404", description = "실패 - 해당 회원을 찾을 수 없습니다."),
-		@ApiResponse(responseCode = "409", description = "실패 - 유효하지 않은 비디오 파일입니다."),
+		@ApiResponse(responseCode = "404", description = "실패 - 해당 회원 또는 비디오를 찾을 수 없습니다."),
 		@ApiResponse(responseCode = "500", description = "실패 - 서버 오류, 요청 처리 중 문제가 발생했습니다.")
 	})
 	public ResponseEntity<String> deleteVideo(

--- a/src/main/java/com/vidcentral/api/presentation/video/VideoController.java
+++ b/src/main/java/com/vidcentral/api/presentation/video/VideoController.java
@@ -132,10 +132,12 @@ public class VideoController {
 		@ApiResponse(responseCode = "404", description = "실패 - 해당 회원을 찾을 수 없습니다."),
 		@ApiResponse(responseCode = "500", description = "실패 - 서버 오류, 요청 처리 중 문제가 발생했습니다.")
 	})
-	public ResponseEntity<List<ViewHistoryListResponse>> searchAllViewHistory(
-		@AuthenticationMember AuthMember authMember) {
+	public ResponseEntity<PageResponse<ViewHistoryListResponse>> searchAllViewHistory(
+		@AuthenticationMember AuthMember authMember,
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "10") int size) {
 
-		return ResponseEntity.ok().body(videoService.searchAllViewHistory(authMember));
+		return ResponseEntity.ok().body(videoService.searchAllViewHistory(authMember, page, size));
 	}
 
 	@GetMapping("/recommendation")

--- a/src/main/java/com/vidcentral/api/presentation/video/VideoController.java
+++ b/src/main/java/com/vidcentral/api/presentation/video/VideoController.java
@@ -94,10 +94,12 @@ public class VideoController {
 		@ApiResponse(responseCode = "404", description = "실패 - 해당 비디오를 찾을 수 없습니다."),
 		@ApiResponse(responseCode = "500", description = "실패 - 서버 오류, 요청 처리 중 문제가 발생했습니다.")
 	})
-	public ResponseEntity<List<VideoListResponse>> searchAllVideosByKeyword(
-		@Valid @RequestPart(required = false) SearchVideoRequest searchVideoRequest) {
+	public ResponseEntity<PageResponse<VideoListResponse>> searchAllVideosByKeyword(
+		@Valid @RequestPart(required = false) SearchVideoRequest searchVideoRequest,
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "10") int size) {
 
-		return ResponseEntity.ok().body(videoService.searchAllVideosByKeyword(searchVideoRequest));
+		return ResponseEntity.ok().body(videoService.searchAllVideosByKeyword(searchVideoRequest, page, size));
 	}
 
 	@GetMapping("/{videoId}")

--- a/src/main/java/com/vidcentral/api/presentation/video/VideoController.java
+++ b/src/main/java/com/vidcentral/api/presentation/video/VideoController.java
@@ -1,7 +1,6 @@
 package com.vidcentral.api.presentation.video;
 
 import java.net.URI;
-import java.util.List;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -151,10 +150,12 @@ public class VideoController {
 		@ApiResponse(responseCode = "404", description = "실패 - 해당 회원을 찾을 수 없습니다."),
 		@ApiResponse(responseCode = "500", description = "실패 - 서버 오류, 요청 처리 중 문제가 발생했습니다.")
 	})
-	public ResponseEntity<List<VideoListResponse>> searchAllRecommendationVideos(
-		@AuthenticationMember AuthMember authMember) {
+	public ResponseEntity<PageResponse<VideoListResponse>> searchAllRecommendationVideos(
+		@AuthenticationMember AuthMember authMember,
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "10") int size) {
 
-		return ResponseEntity.ok().body(videoService.searchAllRecommendationVideos(authMember));
+		return ResponseEntity.ok().body(videoService.searchAllRecommendationVideos(authMember, page, size));
 	}
 
 	@PutMapping("/update/{videoId}")


### PR DESCRIPTION
## 비디오 목록 조회 로직 페이징 처리
- 사용자가 요청하는 페이지에 따라 비디오 목록을 반환하도록 수정했습니다.
- VideoService, ViewHistoryService, RecommendationService, VideoController에서 관련 메서드를 업데이트했습니다.

## 댓글 목록 조회 로직 페이징 처리
- 댓글을 페이지 단위로 조회할 수 있도록 변경했습니다.
- CommentService와 CommentController에서 관련 메서드를 업데이트했습니다.

## 요청 및 응답 DTO Swagger OpenAPI로 문서화
- 모든 요청 및 응답 DTO에 대해 Swagger 어노테이션을 추가하여 API 문서화 작업을 완료했습니다.
- 각 DTO의 필드에 대한 설명과 예시를 추가하여 사용자가 이해할 수 있도록 개선했습니다.