### PR TITLE
비디오 조회 수 증가 API 비동기 처리 및 Redis 동기화

### DIFF
--- a/src/main/java/com/vidcentral/api/application/video/VideoService.java
+++ b/src/main/java/com/vidcentral/api/application/video/VideoService.java
@@ -52,18 +52,16 @@ public class VideoService {
 		return PageMapper.toPageResponse(videoPage.map(VideoMapper::toVideoListResponse));
 	}
 
-	public PageResponse<VideoListResponse> searchAllVideosByKeyword(SearchVideoRequest searchVideoRequest, int page,
-		int size) {
+	public PageResponse<VideoListResponse> searchAllVideosByKeyword(
+		SearchVideoRequest searchVideoRequest, int page, int size) {
 
 		return videoReadService.findAllVideosByKeyword(searchVideoRequest, PageRequest.of(page, size));
 	}
 
 	public VideoDetailResponse searchVideo(AuthMember authMember, Long videoId) {
 		final Video video = videoReadService.findVideo(videoId);
-
 		handleViewHistoryIfLoggedIn(authMember, video);
-		videoWriteService.incrementVideoViews(video);
-
+		videoWriteService.incrementVideoViewsAsync(videoId);
 		return VideoMapper.toVideoDetailsResponse(video);
 	}
 

--- a/src/main/java/com/vidcentral/api/application/video/VideoWriteService.java
+++ b/src/main/java/com/vidcentral/api/application/video/VideoWriteService.java
@@ -1,18 +1,32 @@
 package com.vidcentral.api.application.video;
 
+import static com.vidcentral.global.common.util.GlobalConstant.*;
+import static com.vidcentral.global.common.util.RedisConstant.*;
+import static com.vidcentral.global.error.model.ErrorMessage.*;
+
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import com.vidcentral.api.domain.video.entity.Video;
+import com.vidcentral.api.domain.video.repository.VideoManageRepository;
 import com.vidcentral.api.domain.video.repository.VideoRepository;
 import com.vidcentral.api.dto.request.video.UpdateVideoRequest;
+import com.vidcentral.global.error.exception.NotFoundException;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class VideoWriteService {
 
 	private final VideoRepository videoRepository;
+	private final VideoManageRepository videoManageRepository;
 
 	public Video saveVideo(Video video) {
 		return videoRepository.save(video);
@@ -29,7 +43,30 @@ public class VideoWriteService {
 		videoRepository.delete(video);
 	}
 
-	public void incrementVideoViews(Video video) {
-		video.incrementViews();
+	@Async
+	public void incrementVideoViewsAsync(Long videoId) {
+		CompletableFuture.runAsync(() -> {
+			videoManageRepository.incrementViews(videoId);
+		}).thenAccept(success -> {
+			log.info("[✅ LOGGER] 조회 수 증가가 완료되었습니다.{}", videoId);
+		}).exceptionally(exception -> {
+			log.warn("[❎ LOGGER] 조회 수 증가 중 오류가 발생했습니다.{}", exception.getMessage());
+			throw new NotFoundException(FAILED_VIDEO_NOT_FOUND_ERROR);
+		});
+	}
+
+	@Scheduled(fixedRate = 600000)
+	public void syncVideoViewsFromRedisToMySQL() {
+		Set<String> videoKeys = videoManageRepository.findAllKeys(REDIS_VIDEO_VIEW_PREFIX + WILDCARD);
+
+		for (String key : videoKeys) {
+			final Long videoId = Long.parseLong(key.split(COLON_DELIMITER)[1]);
+			final Long views = videoManageRepository.findViews(videoId);
+
+			if (views != null) {
+				videoRepository.incrementViews(videoId, views);
+				videoManageRepository.deleteViews(videoId);
+			}
+		}
 	}
 }

--- a/src/main/java/com/vidcentral/api/domain/auth/repository/TokenRepository.java
+++ b/src/main/java/com/vidcentral/api/domain/auth/repository/TokenRepository.java
@@ -19,7 +19,8 @@ public class TokenRepository {
 	private final HashRedisRepository hashRedisRepository;
 
 	public void saveToken(String email, TokenSaveResponse tokenSaveResponse) {
-		hashRedisRepository.save(REDIS_REFRESH_TOKEN_PREFIX + email, tokenSaveResponse, Duration.ofDays(EXPIRE_DAYS));
+		hashRedisRepository
+			.save(REDIS_REFRESH_TOKEN_PREFIX + email, tokenSaveResponse, Duration.ofDays(TOKEN_EXPIRE_DAYS));
 	}
 
 	public TokenSaveResponse getTokenSaveValue(String email) {

--- a/src/main/java/com/vidcentral/api/domain/video/repository/VideoManageRepository.java
+++ b/src/main/java/com/vidcentral/api/domain/video/repository/VideoManageRepository.java
@@ -1,0 +1,35 @@
+package com.vidcentral.api.domain.video.repository;
+
+import static com.vidcentral.global.common.util.RedisConstant.*;
+
+import java.time.Duration;
+import java.util.Set;
+
+import org.springframework.stereotype.Repository;
+
+import com.vidcentral.api.infrastructure.redis.HashRedisRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class VideoManageRepository {
+
+	private final HashRedisRepository hashRedisRepository;
+
+	public void incrementViews(Long videoId) {
+		hashRedisRepository.save(REDIS_VIDEO_VIEW_PREFIX + videoId, 1L, Duration.ofMinutes(VIEWS_EXPIRE_MIN));
+	}
+
+	public Set<String> findAllKeys(String pattern) {
+		return hashRedisRepository.getAllKeys(pattern);
+	}
+
+	public Long findViews(Long videoId) {
+		return (Long)hashRedisRepository.get(REDIS_VIDEO_VIEW_PREFIX + videoId);
+	}
+
+	public void deleteViews(Long videoId) {
+		hashRedisRepository.delete(REDIS_VIDEO_VIEW_PREFIX + videoId);
+	}
+}

--- a/src/main/java/com/vidcentral/api/domain/video/repository/VideoRepository.java
+++ b/src/main/java/com/vidcentral/api/domain/video/repository/VideoRepository.java
@@ -3,6 +3,9 @@ package com.vidcentral.api.domain.video.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.vidcentral.api.domain.video.entity.Video;
@@ -13,4 +16,8 @@ public interface VideoRepository extends JpaRepository<Video, Long> {
 	Page<Video> findVideosByTitle(String title, Pageable pageable);
 
 	Page<Video> findVideosByDescription(String description, Pageable pageable);
+
+	@Modifying
+	@Query("UPDATE Video V SET V.views = V.views + :views WHERE V.videoId = :videoId")
+	void incrementViews(@Param("videoId") Long videoId, @Param("views") Long views);
 }

--- a/src/main/java/com/vidcentral/api/infrastructure/redis/HashRedisRepository.java
+++ b/src/main/java/com/vidcentral/api/infrastructure/redis/HashRedisRepository.java
@@ -1,5 +1,7 @@
 package com.vidcentral.api.infrastructure.redis;
 
+import static com.vidcentral.global.error.model.ErrorMessage.*;
+
 import java.time.Duration;
 import java.util.Map;
 
@@ -9,7 +11,6 @@ import org.springframework.data.redis.hash.Jackson2HashMapper;
 import org.springframework.stereotype.Repository;
 
 import com.vidcentral.global.error.exception.NotFoundException;
-import com.vidcentral.global.error.model.ErrorMessage;
 
 @Repository
 public class HashRedisRepository {
@@ -41,7 +42,7 @@ public class HashRedisRepository {
 
 	private void validateTokenEmpty(Map<String, Object> dataMap) {
 		if (dataMap.isEmpty()) {
-			throw new NotFoundException(ErrorMessage.FAILED_TOKEN_NOT_FOUND);
+			throw new NotFoundException(FAILED_TOKEN_NOT_FOUND_ERROR);
 		}
 	}
 }

--- a/src/main/java/com/vidcentral/api/infrastructure/redis/HashRedisRepository.java
+++ b/src/main/java/com/vidcentral/api/infrastructure/redis/HashRedisRepository.java
@@ -4,6 +4,7 @@ import static com.vidcentral.global.error.model.ErrorMessage.*;
 
 import java.time.Duration;
 import java.util.Map;
+import java.util.Set;
 
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -34,6 +35,10 @@ public class HashRedisRepository {
 		final Map<String, Object> memberDataMap = hashOperations.entries(key);
 		validateTokenEmpty(memberDataMap);
 		return jackson2HashMapper.fromHash(memberDataMap);
+	}
+
+	public Set<String> getAllKeys(String pattern) {
+		return redisTemplate.keys(pattern);
 	}
 
 	public void delete(String key) {

--- a/src/main/java/com/vidcentral/global/common/util/GlobalConstant.java
+++ b/src/main/java/com/vidcentral/global/common/util/GlobalConstant.java
@@ -7,7 +7,9 @@ import lombok.NoArgsConstructor;
 public class GlobalConstant {
 
 	public static final String BLANK = "";
-	public static final String DELIMITER = "/";
+	public static final String SLASH_DELIMITER = "/";
+	public static final String COLON_DELIMITER = ":";
+	public static final String WILDCARD = "*";
 
 	public static final String INTRODUCE_ME = "본인 소개에 대한 내용을 작성해주세요.";
 

--- a/src/main/java/com/vidcentral/global/common/util/RedisConstant.java
+++ b/src/main/java/com/vidcentral/global/common/util/RedisConstant.java
@@ -6,5 +6,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class RedisConstant {
 
-	public static final String REDIS_REFRESH_TOKEN_PREFIX = "refreshToken";
+	public static final String REDIS_REFRESH_TOKEN_PREFIX = "refreshToken:";
+	public static final String REDIS_VIDEO_VIEW_PREFIX = "videoView:";
+
+	public static final int TOKEN_EXPIRE_DAYS = 14;
+	public static final int VIEWS_EXPIRE_MIN = 5;
 }

--- a/src/main/java/com/vidcentral/global/common/util/TokenConstant.java
+++ b/src/main/java/com/vidcentral/global/common/util/TokenConstant.java
@@ -13,6 +13,4 @@ public class TokenConstant {
 
 	public static final String ACCESS_TOKEN_HEADER = "Authorization";
 	public static final String REFRESH_TOKEN_COOKIE = "Authorization_RefreshToken";
-
-	public static final int EXPIRE_DAYS = 14;
 }

--- a/src/main/java/com/vidcentral/global/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/vidcentral/global/error/handler/GlobalExceptionHandler.java
@@ -72,6 +72,6 @@ public class GlobalExceptionHandler {
 			.getFieldErrors()
 			.forEach(fieldError -> validationMap.put(fieldError.getField(), fieldError.getDefaultMessage()));
 
-		return new ErrorResponse(FAILED_INVALID_REQUEST.getMessage(), validationMap);
+		return new ErrorResponse(FAILED_INVALID_REQUEST_ERROR.getMessage(), validationMap);
 	}
 }


### PR DESCRIPTION
사용자가 비디오를 조회할 때 즉시 응답을 받을 수 있도록 조회 수 증가 로직을 비동기 처리로 구현했습니다.

## 비동기 처리
- @Async를 통해 조회 수 증가 로직이 비동기적으로 실행되도록 구현했습니다.
- CompletableFuture를 사용해 비동기 작업을 실행하고, 완료 시 로그를 남기도록 구현했습니다.

## 스케줄러
- Redis에 저장된 조회 수를 주기적으로 데이터베이스에 동기화하도록 구현했습니다.
- 모든 조회 수를 10분 단위로 처리함으로써, 데이터베이스에 대한 지속적인 접근을 방지했습니다.

## 데이터베이스 업데이트
- JPA의 @Modifying을 사용해 조회 수를 증가시키는 SQL 쿼리를 실행했습니다.