### PR TITLE
비디오 및 프로필 이미지 업로드 API 개선

### DIFF
--- a/src/main/java/com/vidcentral/api/application/member/MemberService.java
+++ b/src/main/java/com/vidcentral/api/application/member/MemberService.java
@@ -1,7 +1,5 @@
 package com.vidcentral.api.application.member;
 
-import static com.vidcentral.api.domain.image.ImageProperties.*;
-
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -60,7 +58,7 @@ public class MemberService {
 		final Member loginMember = memberReadService.findMember(authMember.email());
 		memberReadService.validateNicknameDuplication(updateMemberRequest.nickname());
 
-		String newProfileImageURL = mediaService.uploadImages(List.of(profileImageURL), PROFILE_IMAGE).get(0);
+		String newProfileImageURL = mediaService.uploadImages(List.of(profileImageURL)).get(0);
 		memberWriteService.changeMemberInfo(loginMember, updateMemberRequest, newProfileImageURL);
 	}
 }

--- a/src/main/java/com/vidcentral/api/application/video/VideoService.java
+++ b/src/main/java/com/vidcentral/api/application/video/VideoService.java
@@ -1,7 +1,5 @@
 package com.vidcentral.api.application.video;
 
-import static com.vidcentral.api.domain.video.entity.VideoProperties.*;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -43,7 +41,7 @@ public class VideoService {
 
 	@Transactional
 	public Video uploadVideo(AuthMember authMember, UploadVideoRequest uploadVideoRequest, MultipartFile newVideoURL) {
-		final String videoURL = mediaService.uploadVideo(newVideoURL, DEFAULT_VIDEO);
+		final String videoURL = mediaService.uploadVideo(newVideoURL);
 		final Member loginMember = memberReadService.findMember(authMember.email());
 
 		videoReadService.validateTagCount(uploadVideoRequest.videoTags());
@@ -90,7 +88,7 @@ public class VideoService {
 		videoReadService.validateMemberHasAccess(video.getMember().getEmail(), loginMember.getEmail());
 		videoReadService.validateTagCount(updateVideoRequest.videoTags());
 
-		final String newVideoURL = mediaService.uploadVideo(videoURL, DEFAULT_VIDEO);
+		final String newVideoURL = mediaService.uploadVideo(videoURL);
 		videoWriteService.updateVideo(video, updateVideoRequest, newVideoURL);
 	}
 

--- a/src/main/java/com/vidcentral/api/domain/image/ImageName.java
+++ b/src/main/java/com/vidcentral/api/domain/image/ImageName.java
@@ -1,7 +1,7 @@
 package com.vidcentral.api.domain.image;
 
-import static com.vidcentral.global.common.util.GlobalConstant.*;
-
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 import org.springframework.web.multipart.MultipartFile;
@@ -14,14 +14,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class ImageName {
 
-	private static final String PROFILE_IMAGE = "members/profile" + SLASH_DELIMITER;
-
 	private final String fileName;
 
-	public static ImageName createFromMultipartFile(MultipartFile multipartFile, ImageProperties imageProperties) {
-		return switch (imageProperties) {
-			case PROFILE_IMAGE ->
-				new ImageName(PROFILE_IMAGE + multipartFile.getName() + "_" + UUID.randomUUID() + IMAGE_EXTENSION);
-		};
+	public static ImageName createFromMultipartFile(MultipartFile multipartFile) {
+		final String originalFileName = multipartFile.getOriginalFilename();
+		final String fileExtension = originalFileName.substring(originalFileName.lastIndexOf('.'));
+		final String encodedFileName = URLEncoder.encode(originalFileName, StandardCharsets.UTF_8);
+
+		return new ImageName(
+			String.format("%s_%s%s", encodedFileName, UUID.randomUUID(), fileExtension));
 	}
 }

--- a/src/main/java/com/vidcentral/api/domain/image/ImageProcessor.java
+++ b/src/main/java/com/vidcentral/api/domain/image/ImageProcessor.java
@@ -1,5 +1,6 @@
 package com.vidcentral.api.domain.image;
 
+import static com.vidcentral.global.common.util.MediaConstant.*;
 import static com.vidcentral.global.error.model.ErrorMessage.*;
 
 import java.awt.*;
@@ -19,10 +20,6 @@ import lombok.extern.slf4j.Slf4j;
 public record ImageProcessor(
 	MultipartFile originalImageFile
 ) {
-
-	private static final String IMAGE_FORMAT_PREFIX = "image/";
-	private static final int MAX_IMAGE_SIZE = 10 * 1024 * 1024;
-
 	public ImageProcessor(MultipartFile originalImageFile) {
 		this.originalImageFile = validateImage(originalImageFile);
 	}
@@ -39,8 +36,9 @@ public record ImageProcessor(
 	}
 
 	private MultipartFile validateImage(MultipartFile imageFile) {
-		if (imageFile.isEmpty() || imageFile.getSize() > MAX_IMAGE_SIZE || !imageFile.getContentType()
-			.startsWith(IMAGE_FORMAT_PREFIX)) {
+		if (imageFile.isEmpty() || imageFile.getSize() > MAX_IMAGE_SIZE ||
+			!ImageProperties.isSupportedContentType(imageFile.getContentType())) {
+
 			throw new BadRequestException(FAILED_S3_RESIZE_ERROR);
 		}
 

--- a/src/main/java/com/vidcentral/api/domain/image/ImageProperties.java
+++ b/src/main/java/com/vidcentral/api/domain/image/ImageProperties.java
@@ -1,5 +1,7 @@
 package com.vidcentral.api.domain.image;
 
+import java.util.Arrays;
+
 import lombok.Getter;
 
 @Getter
@@ -15,4 +17,8 @@ public enum ImageProperties {
 		this.contentType = contentType;
 	}
 
+	public static boolean isSupportedContentType(String contentType) {
+		return Arrays.stream(values())
+			.anyMatch(imageProperties -> imageProperties.contentType.equals(contentType));
+	}
 }

--- a/src/main/java/com/vidcentral/api/domain/member/entity/Member.java
+++ b/src/main/java/com/vidcentral/api/domain/member/entity/Member.java
@@ -1,7 +1,7 @@
 package com.vidcentral.api.domain.member.entity;
 
 import static com.vidcentral.global.common.util.GlobalConstant.*;
-import static com.vidcentral.global.common.util.ImageURL.*;
+import static com.vidcentral.global.common.util.MediaConstant.*;
 import static java.util.Objects.*;
 
 import com.vidcentral.global.common.entity.BaseTimeEntity;

--- a/src/main/java/com/vidcentral/api/domain/video/entity/VideoName.java
+++ b/src/main/java/com/vidcentral/api/domain/video/entity/VideoName.java
@@ -1,7 +1,7 @@
 package com.vidcentral.api.domain.video.entity;
 
-import static com.vidcentral.global.common.util.GlobalConstant.*;
-
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 import org.springframework.web.multipart.MultipartFile;
@@ -14,14 +14,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class VideoName {
 
-	private static final String VIDEO_PATH = "video" + SLASH_DELIMITER;
-
 	private final String fileName;
 
-	public static VideoName createFromMultipartFile(MultipartFile multipartFile, VideoProperties videoProperties) {
-		return switch (videoProperties) {
-			case DEFAULT_VIDEO -> new VideoName(
-				VIDEO_PATH + multipartFile.getOriginalFilename() + "_" + UUID.randomUUID() + VIDEO_EXTENSION);
-		};
+	public static VideoName createFromMultipartFile(MultipartFile multipartFile) {
+		final String originalFileName = multipartFile.getOriginalFilename();
+		final String fileExtension = originalFileName.substring(originalFileName.lastIndexOf('.'));
+		final String encodedFileName = URLEncoder.encode(originalFileName, StandardCharsets.UTF_8);
+
+		return new VideoName(
+			String.format("%s_%s%s", encodedFileName, UUID.randomUUID(), fileExtension));
 	}
 }

--- a/src/main/java/com/vidcentral/api/domain/video/entity/VideoProcessor.java
+++ b/src/main/java/com/vidcentral/api/domain/video/entity/VideoProcessor.java
@@ -1,5 +1,6 @@
 package com.vidcentral.api.domain.video.entity;
 
+import static com.vidcentral.global.common.util.MediaConstant.*;
 import static com.vidcentral.global.error.model.ErrorMessage.*;
 
 import org.springframework.web.multipart.MultipartFile;
@@ -9,17 +10,14 @@ import com.vidcentral.global.error.exception.BadRequestException;
 public record VideoProcessor(
 	MultipartFile originalVideoFile
 ) {
-
-	private static final String VIDEO_FORMAT_PREFIX = "video/";
-	private static final int MAX_VIDEO_SIZE = 10 * 1024 * 1024;
-
 	public VideoProcessor(MultipartFile originalVideoFile) {
 		this.originalVideoFile = validateVideo(originalVideoFile);
 	}
 
 	private MultipartFile validateVideo(MultipartFile videoFile) {
-		if (videoFile.isEmpty() || videoFile.getSize() > MAX_VIDEO_SIZE || !videoFile.getContentType()
-			.startsWith(VIDEO_FORMAT_PREFIX)) {
+		if (videoFile.isEmpty() || videoFile.getSize() > MAX_VIDEO_SIZE ||
+			!VideoProperties.isSupportedContentType(videoFile.getContentType())) {
+
 			throw new BadRequestException(FAILED_INVALID_VIDEO_ERROR);
 		}
 

--- a/src/main/java/com/vidcentral/api/domain/video/entity/VideoProperties.java
+++ b/src/main/java/com/vidcentral/api/domain/video/entity/VideoProperties.java
@@ -1,11 +1,15 @@
 package com.vidcentral.api.domain.video.entity;
 
+import java.util.Arrays;
+
 import lombok.Getter;
 
 @Getter
 public enum VideoProperties {
 
-	DEFAULT_VIDEO(100 * 1024 * 1024, "video/mp4");
+	DEFAULT_VIDEO(100 * 1024 * 1024, "video/mp4"),
+	AVI_VIDEO(100 * 1024 * 1024, "video/x-msvideo"),
+	MKV_VIDEO(100 * 1024 * 1024, "video/x-matroska");
 
 	private final long maxSize;
 	private final String contentType;
@@ -13,5 +17,10 @@ public enum VideoProperties {
 	VideoProperties(long maxSize, String contentType) {
 		this.maxSize = maxSize;
 		this.contentType = contentType;
+	}
+
+	public static boolean isSupportedContentType(String contentType) {
+		return Arrays.stream(values())
+			.anyMatch(videoProperties -> videoProperties.contentType.equals(contentType));
 	}
 }

--- a/src/main/java/com/vidcentral/api/dto/request/video/UploadVideoRequest.java
+++ b/src/main/java/com/vidcentral/api/dto/request/video/UploadVideoRequest.java
@@ -6,6 +6,7 @@ import com.vidcentral.api.domain.video.entity.VideoTag;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.Builder;
 
 @Builder
@@ -19,7 +20,7 @@ public record UploadVideoRequest(
 	@Schema(description = "비디오 설명", example = "videoDescription")
 	String description,
 
-	@NotBlank(message = "비디오 태그는 필수 입력 항목입니다.")
+	@NotEmpty(message = "비디오 태그는 필수 입력 항목입니다.")
 	@Schema(description = "비디오 태그", example = "videoTags")
 	Set<VideoTag> videoTags
 ) {

--- a/src/main/java/com/vidcentral/api/infrastructure/s3/S3ManageService.java
+++ b/src/main/java/com/vidcentral/api/infrastructure/s3/S3ManageService.java
@@ -14,7 +14,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 @Service
 @RequiredArgsConstructor
-public class S3ManagerService {
+public class S3ManageService {
 
 	private final S3Client s3Client;
 
@@ -32,7 +32,7 @@ public class S3ManagerService {
 			s3Client.putObject(putObjectRequest,
 				RequestBody.fromInputStream(multipartFile.getInputStream(), multipartFile.getSize()));
 
-			return "https://" + bucketName + ".s3.ap-northeast-2.amazonaws.com/" + key;
+			return String.format("https://%s.s3.%s.amazonaws.com/%s", bucketName, "ap-northeast-2", key);
 		} catch (IOException e) {
 			throw new RuntimeException("파일 업로드 실패", e);
 		}

--- a/src/main/java/com/vidcentral/global/auth/AuthenticationThreadLocal.java
+++ b/src/main/java/com/vidcentral/global/auth/AuthenticationThreadLocal.java
@@ -14,10 +14,6 @@ public class AuthenticationThreadLocal {
 		AuthenticationThreadLocal.authMemberHolder.set(authMember);
 	}
 
-	public static AuthMember searchAuthMemberHolder() {
-		return authMemberHolder.get();
-	}
-
 	public static void removeAuthMemberHolder() {
 		authMemberHolder.remove();
 	}

--- a/src/main/java/com/vidcentral/global/auth/filter/AuthenticationFilter.java
+++ b/src/main/java/com/vidcentral/global/auth/filter/AuthenticationFilter.java
@@ -47,8 +47,8 @@ public class AuthenticationFilter extends OncePerRequestFilter {
 			}
 
 			if (jwtProviderService.isUsable(refreshToken)) {
-				accessToken = jwtProviderService.reGenerateToken(refreshToken, httpServletResponse);
-				setAuthenticate(accessToken);
+				String newAccessToken = jwtProviderService.reGenerateToken(refreshToken, httpServletResponse);
+				setAuthenticate(newAccessToken);
 				filterChain.doFilter(httpServletRequest, httpServletResponse);
 				return;
 			}
@@ -56,6 +56,7 @@ public class AuthenticationFilter extends OncePerRequestFilter {
 			throw new NotFoundException(FAILED_TOKEN_NOT_FOUND_ERROR);
 		} catch (Exception exception) {
 			log.warn("[✅ LOGGER] JWT 에러 상세 설명: {}", exception.getMessage());
+			httpServletResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 			handlerExceptionResolver.resolveException(httpServletRequest, httpServletResponse, null, exception);
 		} finally {
 			AuthenticationThreadLocal.removeAuthMemberHolder();
@@ -64,8 +65,8 @@ public class AuthenticationFilter extends OncePerRequestFilter {
 
 	protected void setAuthenticate(String accessToken) {
 		final AuthMember authMember = jwtProviderService.extractAuthMemberByAccessToken(accessToken);
-		final Authentication authentication = new UsernamePasswordAuthenticationToken(authMember, BLANK);
-		AuthenticationThreadLocal.saveAuthMemberHolder(authMember);
+		final Authentication authentication = new UsernamePasswordAuthenticationToken(authMember, BLANK, null);
 		SecurityContextHolder.getContext().setAuthentication(authentication);
+		AuthenticationThreadLocal.saveAuthMemberHolder(authMember);
 	}
 }

--- a/src/main/java/com/vidcentral/global/common/util/MediaConstant.java
+++ b/src/main/java/com/vidcentral/global/common/util/MediaConstant.java
@@ -4,9 +4,13 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class ImageURL {
+public class MediaConstant {
 
+	public static final String PROFILE_IMAGE_PATH = "profile-images/";
 	public static final String IMAGE_DOMAIN = "https://image.vidcentral.com/";
-
 	public static final String MEMBER_PROFILE_URL = "vidcentral/default/members-profile.png";
+	public static final long MAX_IMAGE_SIZE = 10 * 1024 * 1024;
+
+	public static final String VIDEO_PATH = "videos/";
+	public static final long MAX_VIDEO_SIZE = 10 * 1024 * 1024;
 }

--- a/src/main/java/com/vidcentral/global/config/SecurityConfig.java
+++ b/src/main/java/com/vidcentral/global/config/SecurityConfig.java
@@ -35,7 +35,8 @@ public class SecurityConfig {
 	};
 	private static final String[] MEMBER_INFO_ENDPOINTS = {
 		"/api/members/**",
-		"/api/videos/**"
+		"/api/videos/**",
+		"/api/comments/**"
 	};
 
 	@Bean
@@ -46,8 +47,7 @@ public class SecurityConfig {
 			.requestMatchers("/v3/api-docs/**")
 			.requestMatchers("/swagger-ui/**")
 			.requestMatchers("/swagger-resources/**")
-			.requestMatchers(HttpMethod.POST, AUTHENTICATION_REQUEST_ENDPOINTS)
-			.requestMatchers(HttpMethod.GET, MEMBER_INFO_ENDPOINTS);
+			.requestMatchers(HttpMethod.POST, AUTHENTICATION_REQUEST_ENDPOINTS);
 	}
 
 	@Bean
@@ -57,8 +57,8 @@ public class SecurityConfig {
 			.sessionManagement(session -> session.sessionCreationPolicy(STATELESS));
 
 		httpSecurity.authorizeHttpRequests(auth -> auth
-			.requestMatchers("/").authenticated()
-			.anyRequest().permitAll());
+			.requestMatchers(HttpMethod.GET, MEMBER_INFO_ENDPOINTS).permitAll()
+			.anyRequest().authenticated());
 
 		httpSecurity.addFilterBefore(
 			new AuthenticationFilter(jwtProviderService, handlerExceptionResolver),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,6 +31,11 @@ spring:
     host: localhost
     port: 6379
 
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+
 cloud:
   aws:
     s3:


### PR DESCRIPTION
## 프로필 이미지 및 비디오 이름 생성 로직 개선
- 프로필 이미지와 비디오 이름 생성 시, 파일 확장자를 명시적으로 추출하여 표현하도록 수정했습니다.
- 파일 이름의 일관성을 높이기 위해 URL 인코딩을 적용하였습니다.

## 파일 업로드 검증 로직 개선
- application.yml 파일에서 Multipart 설정을 추가하여 서버 측에서 파일 크기 제한을 설정했습니다.
- 코드 내에서 프로필 이미지 및 비디오 파일의 최대 크기를 검증하는 로직을 유지하여 에러 메시지를 제공하도록 하였습니다.